### PR TITLE
Fix invalid package list errors in config parsing

### DIFF
--- a/spoof_module.cpp
+++ b/spoof_module.cpp
@@ -214,7 +214,7 @@ private:
             std::unordered_map<std::string, DeviceInfo> new_map;
 
             for (auto& [key, value] : config.items()) {
-                if (key.find("PACKAGES_") != 0) continue; 
+                if (key.find("PACKAGES_") != 0 || key.rfind("_DEVICE") == (key.size() - 7)) continue;
                 if (!value.is_array()) {
                     LOGE("Invalid package list for key %s", key.c_str());
                     continue;


### PR DESCRIPTION
Prevented erroneous "Invalid package list" logs when parsing config.json by skipping keys ending with "_DEVICE" in the reloadIfNeeded function. The previous loop processed all keys starting with "PACKAGES_", including device info objects, causing false error logs. Added a condition to skip keys with "_DEVICE" suffix using rfind, ensuring only package list arrays are processed.