### PR TITLE
v5.0.0: add 6 community languages + changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,8 @@
 *   **App Picker:** Add games straight from your installed apps, complete with real names and icons.
 *   **Backup & Sync:** Export and restore your config, **Sync from GitHub** to pull the latest game list, and export logs — all saved to `Download/COPG`.
 *   **Built-In Console:** Run shell commands, tail logcat, and save logs without ever leaving the app.
-*   **Theming & Language:** Dark / Light / AMOLED / Auto themes, full English **and** Persian (RTL) with one-tap switching, plus haptic feedback.
+*   **Theming & Language:** Dark / Light / AMOLED / Auto themes with one-tap switching and haptic feedback. Now ships in **8 languages** — English, Persian (RTL), Arabic (RTL), German, Spanish, Indonesian, Thai and Chinese.
+*   **Fresh app icon** and a cleaner WebUI title.
 
 ### Simpler, Safer Spoofing
 *   **CPU spoof is now blocked by default.** Every device package is safe out of the box — flip on **With CPU Spoofing** only for the games that need the chipset faked.
@@ -39,6 +40,7 @@
 
 ### Note
 *   This is a massive overhaul and still a work in progress — more is on the way. Please report anything unexpected in the support group.
+*   **Translations:** going forward only **English** and **Persian** are officially maintained. The other languages are community-driven — contributions and fixes via pull request are very welcome.
 
 ### Summary
 v5.0.0 is the biggest release yet: a ground-up WebUI rewrite, a simpler and safer spoofing model (block-by-default CPU), brand-new per-app game tweaks, and a cleaner, faster foundation under the hood.

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -446,6 +446,12 @@
   <script src="js/i18n.js"></script>
   <script src="js/lang/en.js"></script>
   <script src="js/lang/fa.js"></script>
+  <script src="js/lang/ar.js"></script>
+  <script src="js/lang/de.js"></script>
+  <script src="js/lang/es.js"></script>
+  <script src="js/lang/id.js"></script>
+  <script src="js/lang/th.js"></script>
+  <script src="js/lang/zh.js"></script>
   <script src="js/copg-data.js"></script>
   <script src="js/icons.js"></script>
   <script src="js/nav.js"></script>

--- a/webroot/js/lang/ar.js
+++ b/webroot/js/lang/ar.js
@@ -1,0 +1,269 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   ar.js — العربية (Arabic) · RTL
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+I18N.register('ar', {
+  _meta: { name: 'العربية', flag: '🇸🇦', dir: 'rtl' },
+
+  /* Hero */
+  hero_module_id: 'وحدة Zygisk',
+  hero_sub:       'انتحال متقدّم للجهاز والتطبيقات',
+  status_active:   'نشط',
+  status_inactive: 'غير نشط',
+
+  /* Section labels */
+  label_quick_stats: 'إحصائيات سريعة',
+  label_system:      'النظام',
+  label_tools:       'الأدوات',
+  label_appearance:  'المظهر',
+  label_developer:   'المطوّر',
+  label_about:       'حول',
+
+  /* Quick stats */
+  stat_devices:  'الأجهزة',
+  stat_packages: 'الحزم',
+
+  /* System rows */
+  sys_android: 'إصدار أندرويد',
+  sys_abi:     'ABI',
+  sys_zygisk:  'نوع Zygisk',
+  sys_root_version: 'إصدار الروت',
+  sys_kernel:  'إصدار النواة',
+
+  /* Console */
+  console_open:    'فتح وحدة التحكم',
+  console_title:   'وحدة التحكم',
+  console_logcat:  'Logcat',
+  console_clear:   'مسح',
+  console_copy:    'نسخ',
+  console_cmd_ph:  'اكتب أمر شِل…',
+  console_copied:  'تم النسخ إلى الحافظة',
+  console_copy_fail: 'النسخ غير متاح هنا',
+  console_cleared: 'تم مسح وحدة التحكم',
+  console_save:      'حفظ',
+  console_saved:     'تم حفظ السجل في Download/COPG/LOGS',
+  console_saved_dl:  'تم تنزيل السجل',
+  console_save_empty:'لا شيء للحفظ',
+  console_save_fail: 'فشل حفظ السجل',
+
+  /* Page headers */
+  page_library:  'المكتبة',
+  page_settings: 'الإعدادات',
+
+  /* Library tabs + search */
+  tab_devices:     'الأجهزة',
+  tab_packages:    'الحزم',
+  search_devices:  'البحث في الأجهزة…',
+  search_packages: 'البحث في الحزم…',
+  empty_devices:   'لا توجد أجهزة',
+  empty_packages:  'لا توجد حزم',
+
+  /* Settings rows */
+  set_theme:        'السمة',
+  set_language:     'اللغة',
+  set_debug:        'سجلات التصحيح',
+
+  /* Theme hints */
+  theme_auto:   'تلقائي',
+  theme_dark:   'داكن',
+  theme_light:  'فاتح',
+  theme_amoled: 'AMOLED',
+
+  /* Sheets */
+  sheet_theme_title: 'السمة',
+  sheet_lang_title:  'اللغة',
+  theme_opt_auto:   'تلقائي (النظام)',
+  theme_opt_dark:   'داكن',
+  theme_opt_light:  'فاتح',
+  theme_opt_amoled: 'أسود AMOLED',
+
+  /* About */
+  about_module:  'وحدة COPG',
+  about_version: 'الإصدار',
+  about_build:   'تاريخ البناء',
+  about_vcode:   'رقم الإصدار',
+  about_author:  'المطوّر',
+  about_license: 'الترخيص',
+  about_desc:    'وحدة Zygisk تنتحل هوية جهازك — واختيارياً معالجه — لكل لعبة أو تطبيق، لتفتح معدّل إطارات أعلى ورسومات أفضل وميزات مدفوعة محصورة عادةً بهواتف معيّنة. أضِف أو احذف التطبيقات في أي وقت من واجهة الويب هذه، دون الحاجة لإعادة التشغيل.',
+
+  /* Nav */
+  nav_home:     'الرئيسية',
+  nav_library:  'المكتبة',
+  nav_settings: 'الإعدادات',
+
+  /* Toasts */
+  toast_console:   'وحدة التحكم — قريباً',
+  toast_debug_on:  'تم تفعيل سجلات التصحيح',
+  toast_debug_off: 'تم تعطيل سجلات التصحيح',
+  status_connected: 'متصل',
+  status_offline:   'غير متصل',
+
+  /* Library — add buttons & card meta */
+  add_device:   'إضافة جهاز',
+  add_package:  'إضافة حزمة',
+  add_short:    'إضافة',
+  act_edit:     'تعديل',
+  act_delete:   'حذف',
+  dev_model:    'الطراز',
+  dev_games:    'ألعاب',
+  dev_apps:     'تطبيقات',
+  badge_installed: 'مثبّت',
+  preview_unsaved: 'وضع المعاينة — لا تُحفظ التغييرات على الجهاز.',
+
+  /* System — root */
+  sys_root: 'الروت',
+
+  /* Sort + filter */
+  sort_title:     'ترتيب حسب',
+  sort_default:   'افتراضي',
+  sort_name:      'الاسم (أ→ي)',
+  sort_name_za:   'الاسم (ي→أ)',
+  sort_apps:      'عدد التطبيقات',
+  sort_brand:     'العلامة التجارية',
+  sort_device:    'الجهاز',
+  sort_type:      'النوع',
+  sort_installed: 'المثبّتة أولاً',
+  filter_all:      'الكل',
+  filter_user:     'مستخدم',
+  filter_system:   'نظام',
+  filter_installed:'مثبّت',
+  filter_blocked:  'محظور',
+  filter_cpu_only: 'المعالج',
+
+  /* App picker */
+  pick_from_installed: 'اختر من التطبيقات المثبتة',
+  picker_title:   'التطبيقات المثبتة',
+  picker_search:  'البحث في التطبيقات…',
+  picker_empty:   'لا توجد تطبيقات مثبتة',
+  picker_no_results: 'لا توجد تطبيقات',
+  picker_preview: 'وضع المعاينة — ثبّت على الجهاز لعرض التطبيقات',
+  toast_picker_unavailable: 'منتقي التطبيقات غير متاح هنا',
+
+  /* Backup & Sync */
+  lib_backup:           'النسخ الاحتياطي والمزامنة',
+  backup_title:         'النسخ الاحتياطي والمزامنة',
+  backup_intro:         'انسخ أجهزتك وحزمك احتياطياً، أو استعد نسخة سابقة، أو زامن أحدث إعداد من GitHub.',
+  backup_export:        'تصدير نسخة احتياطية',
+  backup_export_sub:    'حفظ البيانات الحالية في التنزيلات',
+  backup_import:        'استيراد واستعادة',
+  backup_import_sub:    'استعادة البيانات من نسخة احتياطية',
+  backup_empty:         'لا توجد نسخ احتياطية في Downloads/COPG',
+  backup_from_file:     'استيراد من ملف…',
+  backup_confirm_title: 'استعادة النسخة الاحتياطية؟',
+  backup_confirm_msg:   'سيؤدي هذا إلى استبدال أجهزتك وحزمك الحالية بـ:',
+  backup_restore:       'استعادة',
+  toast_backup_ok:      'تم حفظ النسخة الاحتياطية',
+  toast_backup_fail:    'فشل النسخ الاحتياطي',
+  toast_restore_ok:     'تمت الاستعادة',
+  toast_restore_fail:   'فشلت الاستعادة',
+  toast_invalid_json:   'ملف JSON غير صالح',
+
+  /* Import type chooser */
+  backup_kind_title:       'ما نوع هذا الملف؟',
+  backup_kind_config:      'الأجهزة والحزم',
+  backup_kind_config_sub:  'إعداد الأجهزة والحزم (COPG.json)',
+  backup_kind_list:        'أسماء العرض',
+  backup_kind_list_sub:    'أسماء عرض الحزم (list.json)',
+  backup_kind_detected:    'تم الكشف',
+
+  /* Sync from GitHub */
+  backup_sync:        'مزامنة من GitHub',
+  backup_sync_sub:    'جلب أحدث إعداد من المستودع',
+  toast_sync_ok:      'تمت المزامنة من GitHub',
+  toast_sync_fail:    'فشلت المزامنة — تحقق من اتصالك',
+  toast_sync_preview: 'المزامنة تعمل على الجهاز فقط',
+
+  /* Package types (chips) */
+  pkgtype_device:   'جهاز',
+  pkgtype_cpu_only: 'انتحال المعالج',
+  pkgtype_blocked:  'حظر انتحال المعالج',
+
+  /* Package tags (chips) */
+  tag_withcpu:  'مع المعالج',
+  tag_got:      'GOT',
+  tag_dnd:      'عدم الإزعاج',
+  tag_dab:      'سطوع تلقائي',
+  tag_kso:      'إبقاء الشاشة',
+  tag_nolog:    'بدون سجل',
+
+  /* Device modal */
+  dev_add_title:      'إضافة جهاز',
+  dev_edit_title:     'تعديل الجهاز',
+  dev_f_name:         'اسم الجهاز',
+  dev_f_brand:        'العلامة التجارية',
+  dev_f_model:        'الطراز',
+  dev_f_manufacturer: 'الشركة المصنّعة',
+  dev_f_fingerprint:  'البصمة',
+  dev_f_android:      'إصدار أندرويد',
+  dev_f_sdk:          'SDK Int',
+  dev_f_serial:       'الرقم التسلسلي',
+  opt_optional:       '(اختياري)',
+  serial_gen:         'توليد',
+  info_sdk_title:     'SDK Int',
+  info_sdk_msg:       'مستوى SDK وإصدار أندرويد زوج متطابق — يُملأ تلقائياً من إصدار أندرويد. إذا ضبطت SDK لا يطابق الإصدار، فقد تكتشف بعض التطبيقات عدم التطابق وتتعطّل. عدّله يدوياً فقط لإصدار أندرويد جديد لا تعرفه الوحدة بعد.',
+
+  /* Package modal */
+  pkg_add_title:  'إضافة حزمة',
+  pkg_edit_title: 'تعديل الحزمة',
+  pkg_f_package:  'اسم الحزمة',
+  pkg_f_name:     'اسم العرض',
+  pkg_f_type:     'النوع',
+  pkg_f_device:   'ملف الجهاز',
+  pkg_no_devices: 'لا توجد أجهزة — أضِف واحداً أولاً',
+  pkg_sec_spoofing: 'الانتحال',
+  pkg_sec_tweaks:   'التعديلات',
+  pkg_t_withcpu:  'انتحال المعالج',
+  pkg_t_got:      'GOT Hooking',
+  pkg_t_dnd:      'عدم الإزعاج',
+  pkg_t_dab:      'تعطيل السطوع التلقائي',
+  pkg_t_kso:      'إبقاء الشاشة مضاءة',
+  pkg_t_nolog:    'تعطيل التسجيل',
+
+  /* GOT Hooking warning */
+  got_warn_title: 'تفعيل GOT Hooking؟',
+  got_warn_msg:   'يُبقي GOT Hooking الوحدة مقيمة في ذاكرة التطبيق أو اللعبة. يمكن اكتشاف ذلك وقد يؤدي حتى إلى حظر حساب لعبتك.\n\nهل أنت متأكد من تفعيله؟ ننصح بسؤال المجتمع قبل اتخاذ القرار.',
+  got_warn_ok:    'تفعيل على أي حال',
+  got_warn_link:  'مجتمع COPG على تيليجرام',
+
+  /* Toggle info popups */
+  info_aria:           'ما هذا؟',
+  info_ok:             'فهمت',
+  info_withcpu_title:  'انتحال المعالج',
+  info_withcpu_msg:    'بالإضافة إلى تزييف طراز الجهاز، يزيّف هذا أيضاً تفاصيل معالج هاتفك (CPU) لهذا التطبيق. فعّله للألعاب التي تفحص الشريحة. اتركه مُطفأً (الافتراضي) ويبقى تزييف المعالج محظوراً — وهو ما تفضّله التطبيقات البنكية والحساسة.',
+  info_got_title:      'GOT Hooking',
+  info_got_msg:        'طريقة أعمق وأكثر عدوانية لتطبيق الانتحال من داخل ذاكرة التطبيق. أقوى لكن أخطر: يمكن اكتشافها وقد تؤدي إلى حظر حساب لعبة. فعّلها فقط إذا كنت تعلم أنك تحتاجها.',
+  info_dnd_title:      'عدم الإزعاج',
+  info_dnd_msg:        'يُسكت المكالمات والإشعارات أثناء وجودك في هذه اللعبة، فلا يقاطع شيء مباراتك. يعود إعدادك المعتاد عند الخروج.',
+  info_dab_title:      'تعطيل السطوع التلقائي',
+  info_dab_msg:        'يمنع الشاشة من التعتيم والإضاءة التلقائية أثناء اللعب، فيبقى السطوع كما ضبطته. يُستعاد تلقائياً عند مغادرة اللعبة.',
+  info_kso_title:      'إبقاء الشاشة مضاءة',
+  info_kso_msg:        'يُبقي الشاشة مضاءة أثناء فتح هذه اللعبة حتى لو لم تلمسها — لا مزيد من انطفاء الشاشة وسط المباراة. تعود مهلتك المعتادة عند الخروج.',
+  info_nolog_title:    'تعطيل التسجيل',
+  info_nolog_msg:      'يوقف مؤقتاً جامع سجلات النظام أثناء لعبك لتوفير قليل من المعالج والتخزين. يعود للعمل تلقائياً عند مغادرة اللعبة.',
+
+  /* Buttons */
+  btn_cancel: 'إلغاء',
+  btn_save:   'حفظ',
+  btn_delete: 'حذف',
+
+  /* Validation messages */
+  msg_required:    'مطلوب',
+  msg_duplicate:   'مكرر',
+  msg_dup_device:  'يوجد جهاز بهذا الاسم بالفعل',
+  msg_dup_model:   'يوجد جهاز بهذا الطراز بالفعل',
+  msg_pick_device: 'اختر جهازاً',
+  msg_dup_pkg:     'هذه الحزمة موجودة بالفعل في',
+
+  /* Confirm delete */
+  confirm_del_device_title:  'حذف الجهاز؟',
+  confirm_del_package_title: 'حذف الحزمة؟',
+
+  /* Toasts — CRUD */
+  toast_device_added:    'تمت إضافة الجهاز',
+  toast_device_saved:    'تم حفظ الجهاز',
+  toast_device_deleted:  'تم حذف الجهاز',
+  toast_package_added:   'تمت إضافة الحزمة',
+  toast_package_saved:   'تم حفظ الحزمة',
+  toast_package_deleted: 'تم حذف الحزمة',
+  toast_preview_only:    'معاينة فقط — لم تُحفظ على الجهاز',
+  toast_save_failed:     'فشل الحفظ',
+});

--- a/webroot/js/lang/de.js
+++ b/webroot/js/lang/de.js
@@ -1,0 +1,269 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   de.js — Deutsch (German)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+I18N.register('de', {
+  _meta: { name: 'Deutsch', flag: '🇩🇪', dir: 'ltr' },
+
+  /* Hero */
+  hero_module_id: 'Zygisk-Modul',
+  hero_sub:       'Erweitertes Geräte- & App-Spoofing',
+  status_active:   'Aktiv',
+  status_inactive: 'Inaktiv',
+
+  /* Section labels */
+  label_quick_stats: 'Schnellstatistik',
+  label_system:      'System',
+  label_tools:       'Werkzeuge',
+  label_appearance:  'Darstellung',
+  label_developer:   'Entwickler',
+  label_about:       'Über',
+
+  /* Quick stats */
+  stat_devices:  'Geräte',
+  stat_packages: 'Pakete',
+
+  /* System rows */
+  sys_android: 'Android-Version',
+  sys_abi:     'ABI',
+  sys_zygisk:  'Zygisk-Variante',
+  sys_root_version: 'Root-Version',
+  sys_kernel:  'Kernel-Version',
+
+  /* Console */
+  console_open:    'Konsole öffnen',
+  console_title:   'Konsole',
+  console_logcat:  'Logcat',
+  console_clear:   'Löschen',
+  console_copy:    'Kopieren',
+  console_cmd_ph:  'Shell-Befehl eingeben…',
+  console_copied:  'In die Zwischenablage kopiert',
+  console_copy_fail: 'Kopieren hier nicht verfügbar',
+  console_cleared: 'Konsole geleert',
+  console_save:      'Speichern',
+  console_saved:     'Protokoll in Download/COPG/LOGS gespeichert',
+  console_saved_dl:  'Protokoll heruntergeladen',
+  console_save_empty:'Nichts zu speichern',
+  console_save_fail: 'Protokoll speichern fehlgeschlagen',
+
+  /* Page headers */
+  page_library:  'Bibliothek',
+  page_settings: 'Einstellungen',
+
+  /* Library tabs + search */
+  tab_devices:     'Geräte',
+  tab_packages:    'Pakete',
+  search_devices:  'Geräte suchen…',
+  search_packages: 'Pakete suchen…',
+  empty_devices:   'Keine Geräte gefunden',
+  empty_packages:  'Keine Pakete gefunden',
+
+  /* Settings rows */
+  set_theme:        'Design',
+  set_language:     'Sprache',
+  set_debug:        'Debug-Protokolle',
+
+  /* Theme hints */
+  theme_auto:   'Auto',
+  theme_dark:   'Dunkel',
+  theme_light:  'Hell',
+  theme_amoled: 'AMOLED',
+
+  /* Sheets */
+  sheet_theme_title: 'Design',
+  sheet_lang_title:  'Sprache',
+  theme_opt_auto:   'Auto (System)',
+  theme_opt_dark:   'Dunkel',
+  theme_opt_light:  'Hell',
+  theme_opt_amoled: 'AMOLED-Schwarz',
+
+  /* About */
+  about_module:  'COPG-Modul',
+  about_version: 'Version',
+  about_build:   'Build-Datum',
+  about_vcode:   'Versionscode',
+  about_author:  'Autor',
+  about_license: 'Lizenz',
+  about_desc:    'Ein Zygisk-Modul, das dein Gerät — und optional dessen CPU — pro Spiel oder App vortäuscht und so höhere FPS, bessere Grafik und Premium-Funktionen freischaltet, die sonst bestimmten Handys vorbehalten sind. Apps jederzeit über diese WebUI hinzufügen oder entfernen, ohne Neustart.',
+
+  /* Nav */
+  nav_home:     'Start',
+  nav_library:  'Bibliothek',
+  nav_settings: 'Einstellungen',
+
+  /* Toasts */
+  toast_console:   'Konsole — demnächst',
+  toast_debug_on:  'Debug-Protokolle aktiviert',
+  toast_debug_off: 'Debug-Protokolle deaktiviert',
+  status_connected: 'Verbunden',
+  status_offline:   'Offline',
+
+  /* Library — add buttons & card meta */
+  add_device:   'Gerät hinzufügen',
+  add_package:  'Paket hinzufügen',
+  add_short:    'Hinzufügen',
+  act_edit:     'Bearbeiten',
+  act_delete:   'Löschen',
+  dev_model:    'Modell',
+  dev_games:    'Spiele',
+  dev_apps:     'Apps',
+  badge_installed: 'Installiert',
+  preview_unsaved: 'Vorschaumodus — Änderungen werden nicht auf dem Gerät gespeichert.',
+
+  /* System — root */
+  sys_root: 'Root',
+
+  /* Sort + filter */
+  sort_title:     'Sortieren nach',
+  sort_default:   'Standard',
+  sort_name:      'Name (A→Z)',
+  sort_name_za:   'Name (Z→A)',
+  sort_apps:      'App-Anzahl',
+  sort_brand:     'Marke',
+  sort_device:    'Gerät',
+  sort_type:      'Typ',
+  sort_installed: 'Installierte zuerst',
+  filter_all:      'Alle',
+  filter_user:     'Benutzer',
+  filter_system:   'System',
+  filter_installed:'Installiert',
+  filter_blocked:  'Blockiert',
+  filter_cpu_only: 'CPU',
+
+  /* App picker */
+  pick_from_installed: 'Aus installierten Apps wählen',
+  picker_title:   'Installierte Apps',
+  picker_search:  'Apps suchen…',
+  picker_empty:   'Keine installierten Apps gefunden',
+  picker_no_results: 'Keine Apps gefunden',
+  picker_preview: 'Vorschaumodus — auf dem Gerät installieren, um Apps aufzulisten',
+  toast_picker_unavailable: 'App-Auswahl hier nicht verfügbar',
+
+  /* Backup & Sync */
+  lib_backup:           'Sicherung & Sync',
+  backup_title:         'Sicherung & Sync',
+  backup_intro:         'Sichere deine Geräte & Pakete, stelle eine frühere Sicherung wieder her oder synchronisiere die neueste Konfiguration von GitHub.',
+  backup_export:        'Sicherung exportieren',
+  backup_export_sub:    'Aktuelle Daten in Downloads speichern',
+  backup_import:        'Importieren & wiederherstellen',
+  backup_import_sub:    'Daten aus einer Sicherung wiederherstellen',
+  backup_empty:         'Keine Sicherungen in Downloads/COPG gefunden',
+  backup_from_file:     'Aus Datei importieren…',
+  backup_confirm_title: 'Sicherung wiederherstellen?',
+  backup_confirm_msg:   'Dadurch werden deine aktuellen Geräte & Pakete überschrieben mit:',
+  backup_restore:       'Wiederherstellen',
+  toast_backup_ok:      'Sicherung gespeichert',
+  toast_backup_fail:    'Sicherung fehlgeschlagen',
+  toast_restore_ok:     'Sicherung wiederhergestellt',
+  toast_restore_fail:   'Wiederherstellung fehlgeschlagen',
+  toast_invalid_json:   'Keine gültige JSON-Datei',
+
+  /* Import type chooser */
+  backup_kind_title:       'Welche Art Datei ist das?',
+  backup_kind_config:      'Geräte & Pakete',
+  backup_kind_config_sub:  'Geräte- & Paketkonfiguration (COPG.json)',
+  backup_kind_list:        'Anzeigenamen',
+  backup_kind_list_sub:    'Anzeigenamen der Pakete (list.json)',
+  backup_kind_detected:    'erkannt',
+
+  /* Sync from GitHub */
+  backup_sync:        'Von GitHub synchronisieren',
+  backup_sync_sub:    'Neueste Konfiguration aus dem Repo abrufen',
+  toast_sync_ok:      'Von GitHub synchronisiert',
+  toast_sync_fail:    'Sync fehlgeschlagen — prüfe deine Verbindung',
+  toast_sync_preview: 'Sync funktioniert nur auf dem Gerät',
+
+  /* Package types (chips) */
+  pkgtype_device:   'Gerät',
+  pkgtype_cpu_only: 'CPU-Spoof',
+  pkgtype_blocked:  'CPU-Spoof blockieren',
+
+  /* Package tags (chips) */
+  tag_withcpu:  'Mit CPU',
+  tag_got:      'GOT',
+  tag_dnd:      'Nicht stören',
+  tag_dab:      'Auto-Helligkeit',
+  tag_kso:      'Bildschirm an',
+  tag_nolog:    'Kein Log',
+
+  /* Device modal */
+  dev_add_title:      'Gerät hinzufügen',
+  dev_edit_title:     'Gerät bearbeiten',
+  dev_f_name:         'Gerätename',
+  dev_f_brand:        'Marke',
+  dev_f_model:        'Modell',
+  dev_f_manufacturer: 'Hersteller',
+  dev_f_fingerprint:  'Fingerprint',
+  dev_f_android:      'Android-Version',
+  dev_f_sdk:          'SDK Int',
+  dev_f_serial:       'Seriennummer',
+  opt_optional:       '(optional)',
+  serial_gen:         'Generieren',
+  info_sdk_title:     'SDK Int',
+  info_sdk_msg:       'SDK-Level und Android-Version gehören zusammen — es wird automatisch aus der Android-Version ausgefüllt. Wenn du ein nicht passendes SDK einstellst, erkennen manche Apps die Abweichung und stürzen ab. Bearbeite es nur von Hand für eine brandneue Android-Version, die das Modul noch nicht kennt.',
+
+  /* Package modal */
+  pkg_add_title:  'Paket hinzufügen',
+  pkg_edit_title: 'Paket bearbeiten',
+  pkg_f_package:  'Paketname',
+  pkg_f_name:     'Anzeigename',
+  pkg_f_type:     'Typ',
+  pkg_f_device:   'Geräteprofil',
+  pkg_no_devices: 'Keine Geräte — zuerst eins hinzufügen',
+  pkg_sec_spoofing: 'Spoofing',
+  pkg_sec_tweaks:   'Optimierungen',
+  pkg_t_withcpu:  'Mit CPU-Spoofing',
+  pkg_t_got:      'GOT Hooking',
+  pkg_t_dnd:      'Nicht stören',
+  pkg_t_dab:      'Auto-Helligkeit deaktivieren',
+  pkg_t_kso:      'Bildschirm anlassen',
+  pkg_t_nolog:    'Protokollierung deaktivieren',
+
+  /* GOT Hooking warning */
+  got_warn_title: 'GOT Hooking aktivieren?',
+  got_warn_msg:   'GOT Hooking hält das Modul im Speicher der App oder des Spiels resident. Das kann erkannt werden und sogar zur Sperrung deines Spielkontos führen.\n\nBist du sicher, dass du es aktivieren willst? Wir empfehlen, vorher die Community zu fragen.',
+  got_warn_ok:    'Trotzdem aktivieren',
+  got_warn_link:  'COPG-Community auf Telegram',
+
+  /* Toggle info popups */
+  info_aria:           'Was ist das?',
+  info_ok:             'Verstanden',
+  info_withcpu_title:  'Mit CPU-Spoofing',
+  info_withcpu_msg:    'Zusätzlich zum Vortäuschen des Gerätemodells werden auch die Prozessor-Details (CPU) deines Telefons für diese App vorgetäuscht. Aktiviere es für Spiele, die den Chipsatz prüfen. Lass es aus (Standard), dann bleibt das CPU-Spoofing blockiert — was Banking- und sensible Apps bevorzugen.',
+  info_got_title:      'GOT Hooking',
+  info_got_msg:        'Eine tiefere, aggressivere Methode, das Spoofing aus dem Speicher der App heraus anzuwenden. Stärker, aber riskanter: Es kann erkannt werden und sogar zur Sperrung eines Spielkontos führen. Aktiviere es nur, wenn du weißt, dass du es brauchst.',
+  info_dnd_title:      'Nicht stören',
+  info_dnd_msg:        'Schaltet Anrufe und Benachrichtigungen stumm, während du in diesem Spiel bist, damit nichts dein Match unterbricht. Deine normale Einstellung kehrt beim Verlassen zurück.',
+  info_dab_title:      'Auto-Helligkeit deaktivieren',
+  info_dab_msg:        'Verhindert, dass sich der Bildschirm beim Spielen automatisch abdunkelt und aufhellt, sodass die Helligkeit bleibt, wie du sie eingestellt hast. Wird beim Verlassen des Spiels automatisch wiederhergestellt.',
+  info_kso_title:      'Bildschirm anlassen',
+  info_kso_msg:        'Hält den Bildschirm wach, während dieses Spiel geöffnet ist, auch wenn du es nicht berührst — kein Bildschirm-Aus mitten im Match mehr. Dein normales Timeout kehrt beim Verlassen zurück.',
+  info_nolog_title:    'Protokollierung deaktivieren',
+  info_nolog_msg:      'Pausiert den System-Protokollsammler beim Spielen, um etwas CPU und Speicher freizugeben. Schaltet sich beim Verlassen des Spiels von selbst wieder ein.',
+
+  /* Buttons */
+  btn_cancel: 'Abbrechen',
+  btn_save:   'Speichern',
+  btn_delete: 'Löschen',
+
+  /* Validation messages */
+  msg_required:    'Erforderlich',
+  msg_duplicate:   'Duplikat',
+  msg_dup_device:  'Ein Gerät mit diesem Namen existiert bereits',
+  msg_dup_model:   'Ein Gerät mit diesem Modell existiert bereits',
+  msg_pick_device: 'Gerät auswählen',
+  msg_dup_pkg:     'Dieses Paket existiert bereits in',
+
+  /* Confirm delete */
+  confirm_del_device_title:  'Gerät löschen?',
+  confirm_del_package_title: 'Paket löschen?',
+
+  /* Toasts — CRUD */
+  toast_device_added:    'Gerät hinzugefügt',
+  toast_device_saved:    'Gerät gespeichert',
+  toast_device_deleted:  'Gerät gelöscht',
+  toast_package_added:   'Paket hinzugefügt',
+  toast_package_saved:   'Paket gespeichert',
+  toast_package_deleted: 'Paket gelöscht',
+  toast_preview_only:    'Nur Vorschau — nicht auf dem Gerät gespeichert',
+  toast_save_failed:     'Speichern fehlgeschlagen',
+});

--- a/webroot/js/lang/es.js
+++ b/webroot/js/lang/es.js
@@ -1,0 +1,269 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   es.js — Español (Spanish)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+I18N.register('es', {
+  _meta: { name: 'Español', flag: '🇪🇸', dir: 'ltr' },
+
+  /* Hero */
+  hero_module_id: 'Módulo Zygisk',
+  hero_sub:       'Suplantación avanzada de dispositivo y apps',
+  status_active:   'Activo',
+  status_inactive: 'Inactivo',
+
+  /* Section labels */
+  label_quick_stats: 'Estadísticas',
+  label_system:      'Sistema',
+  label_tools:       'Herramientas',
+  label_appearance:  'Apariencia',
+  label_developer:   'Desarrollador',
+  label_about:       'Acerca de',
+
+  /* Quick stats */
+  stat_devices:  'Dispositivos',
+  stat_packages: 'Paquetes',
+
+  /* System rows */
+  sys_android: 'Versión de Android',
+  sys_abi:     'ABI',
+  sys_zygisk:  'Variante de Zygisk',
+  sys_root_version: 'Versión de root',
+  sys_kernel:  'Versión del kernel',
+
+  /* Console */
+  console_open:    'Abrir consola',
+  console_title:   'Consola',
+  console_logcat:  'Logcat',
+  console_clear:   'Borrar',
+  console_copy:    'Copiar',
+  console_cmd_ph:  'Escribe un comando de shell…',
+  console_copied:  'Copiado al portapapeles',
+  console_copy_fail: 'Copiar no disponible aquí',
+  console_cleared: 'Consola borrada',
+  console_save:      'Guardar',
+  console_saved:     'Registro guardado en Download/COPG/LOGS',
+  console_saved_dl:  'Registro descargado',
+  console_save_empty:'Nada que guardar',
+  console_save_fail: 'Error al guardar el registro',
+
+  /* Page headers */
+  page_library:  'Biblioteca',
+  page_settings: 'Ajustes',
+
+  /* Library tabs + search */
+  tab_devices:     'Dispositivos',
+  tab_packages:    'Paquetes',
+  search_devices:  'Buscar dispositivos…',
+  search_packages: 'Buscar paquetes…',
+  empty_devices:   'No se encontraron dispositivos',
+  empty_packages:  'No se encontraron paquetes',
+
+  /* Settings rows */
+  set_theme:        'Tema',
+  set_language:     'Idioma',
+  set_debug:        'Registros de depuración',
+
+  /* Theme hints */
+  theme_auto:   'Auto',
+  theme_dark:   'Oscuro',
+  theme_light:  'Claro',
+  theme_amoled: 'AMOLED',
+
+  /* Sheets */
+  sheet_theme_title: 'Tema',
+  sheet_lang_title:  'Idioma',
+  theme_opt_auto:   'Auto (Sistema)',
+  theme_opt_dark:   'Oscuro',
+  theme_opt_light:  'Claro',
+  theme_opt_amoled: 'Negro AMOLED',
+
+  /* About */
+  about_module:  'Módulo COPG',
+  about_version: 'Versión',
+  about_build:   'Fecha de compilación',
+  about_vcode:   'Código de versión',
+  about_author:  'Autor',
+  about_license: 'Licencia',
+  about_desc:    'Un módulo Zygisk que suplanta tu dispositivo — y opcionalmente su CPU — por juego o app, desbloqueando más FPS, mejores gráficos y funciones premium normalmente limitadas a ciertos teléfonos. Añade o quita apps cuando quieras desde esta WebUI, sin reiniciar.',
+
+  /* Nav */
+  nav_home:     'Inicio',
+  nav_library:  'Biblioteca',
+  nav_settings: 'Ajustes',
+
+  /* Toasts */
+  toast_console:   'Consola — próximamente',
+  toast_debug_on:  'Registros de depuración activados',
+  toast_debug_off: 'Registros de depuración desactivados',
+  status_connected: 'Conectado',
+  status_offline:   'Sin conexión',
+
+  /* Library — add buttons & card meta */
+  add_device:   'Añadir dispositivo',
+  add_package:  'Añadir paquete',
+  add_short:    'Añadir',
+  act_edit:     'Editar',
+  act_delete:   'Eliminar',
+  dev_model:    'Modelo',
+  dev_games:    'juegos',
+  dev_apps:     'apps',
+  badge_installed: 'Instalada',
+  preview_unsaved: 'Modo vista previa — los cambios no se guardan en el dispositivo.',
+
+  /* System — root */
+  sys_root: 'Root',
+
+  /* Sort + filter */
+  sort_title:     'Ordenar por',
+  sort_default:   'Predeterminado',
+  sort_name:      'Nombre (A→Z)',
+  sort_name_za:   'Nombre (Z→A)',
+  sort_apps:      'Nº de apps',
+  sort_brand:     'Marca',
+  sort_device:    'Dispositivo',
+  sort_type:      'Tipo',
+  sort_installed: 'Instaladas primero',
+  filter_all:      'Todas',
+  filter_user:     'Usuario',
+  filter_system:   'Sistema',
+  filter_installed:'Instaladas',
+  filter_blocked:  'Bloqueadas',
+  filter_cpu_only: 'CPU',
+
+  /* App picker */
+  pick_from_installed: 'Elegir de las apps instaladas',
+  picker_title:   'Apps instaladas',
+  picker_search:  'Buscar apps…',
+  picker_empty:   'No hay apps instaladas',
+  picker_no_results: 'No se encontraron apps',
+  picker_preview: 'Modo vista previa — instala en el dispositivo para ver apps',
+  toast_picker_unavailable: 'Selector de apps no disponible aquí',
+
+  /* Backup & Sync */
+  lib_backup:           'Copia y sincronización',
+  backup_title:         'Copia y sincronización',
+  backup_intro:         'Haz copia de tus dispositivos y paquetes, restaura una copia anterior o sincroniza la última configuración desde GitHub.',
+  backup_export:        'Exportar copia',
+  backup_export_sub:    'Guardar los datos actuales en Descargas',
+  backup_import:        'Importar y restaurar',
+  backup_import_sub:    'Restaurar datos desde una copia',
+  backup_empty:         'No hay copias en Downloads/COPG',
+  backup_from_file:     'Importar desde archivo…',
+  backup_confirm_title: '¿Restaurar copia?',
+  backup_confirm_msg:   'Esto sobrescribirá tus dispositivos y paquetes actuales con:',
+  backup_restore:       'Restaurar',
+  toast_backup_ok:      'Copia guardada',
+  toast_backup_fail:    'Error en la copia',
+  toast_restore_ok:     'Copia restaurada',
+  toast_restore_fail:   'Error al restaurar',
+  toast_invalid_json:   'Archivo JSON no válido',
+
+  /* Import type chooser */
+  backup_kind_title:       '¿Qué tipo de archivo es?',
+  backup_kind_config:      'Dispositivos y paquetes',
+  backup_kind_config_sub:  'Config de dispositivos y paquetes (COPG.json)',
+  backup_kind_list:        'Nombres visibles',
+  backup_kind_list_sub:    'Nombres visibles de paquetes (list.json)',
+  backup_kind_detected:    'detectado',
+
+  /* Sync from GitHub */
+  backup_sync:        'Sincronizar desde GitHub',
+  backup_sync_sub:    'Obtener la última configuración del repositorio',
+  toast_sync_ok:      'Sincronizado desde GitHub',
+  toast_sync_fail:    'Error de sincronización — revisa tu conexión',
+  toast_sync_preview: 'La sincronización solo funciona en el dispositivo',
+
+  /* Package types (chips) */
+  pkgtype_device:   'Dispositivo',
+  pkgtype_cpu_only: 'Suplantar CPU',
+  pkgtype_blocked:  'Bloquear suplantación de CPU',
+
+  /* Package tags (chips) */
+  tag_withcpu:  'Con CPU',
+  tag_got:      'GOT',
+  tag_dnd:      'No molestar',
+  tag_dab:      'Brillo auto',
+  tag_kso:      'Pantalla on',
+  tag_nolog:    'Sin log',
+
+  /* Device modal */
+  dev_add_title:      'Añadir dispositivo',
+  dev_edit_title:     'Editar dispositivo',
+  dev_f_name:         'Nombre del dispositivo',
+  dev_f_brand:        'Marca',
+  dev_f_model:        'Modelo',
+  dev_f_manufacturer: 'Fabricante',
+  dev_f_fingerprint:  'Huella (fingerprint)',
+  dev_f_android:      'Versión de Android',
+  dev_f_sdk:          'SDK Int',
+  dev_f_serial:       'Número de serie',
+  opt_optional:       '(opcional)',
+  serial_gen:         'Generar',
+  info_sdk_title:     'SDK Int',
+  info_sdk_msg:       'El nivel de SDK y la versión de Android van emparejados — se rellena automáticamente desde la versión de Android. Si pones un SDK que no coincide, algunas apps detectan el desajuste y se cierran. Edítalo a mano solo para una versión de Android nueva que el módulo aún no conozca.',
+
+  /* Package modal */
+  pkg_add_title:  'Añadir paquete',
+  pkg_edit_title: 'Editar paquete',
+  pkg_f_package:  'Nombre del paquete',
+  pkg_f_name:     'Nombre visible',
+  pkg_f_type:     'Tipo',
+  pkg_f_device:   'Perfil de dispositivo',
+  pkg_no_devices: 'Sin dispositivos — añade uno primero',
+  pkg_sec_spoofing: 'Suplantación',
+  pkg_sec_tweaks:   'Ajustes',
+  pkg_t_withcpu:  'Con suplantación de CPU',
+  pkg_t_got:      'GOT Hooking',
+  pkg_t_dnd:      'No molestar',
+  pkg_t_dab:      'Desactivar brillo automático',
+  pkg_t_kso:      'Mantener pantalla encendida',
+  pkg_t_nolog:    'Desactivar registro',
+
+  /* GOT Hooking warning */
+  got_warn_title: '¿Activar GOT Hooking?',
+  got_warn_msg:   'GOT Hooking mantiene el módulo residente en la memoria de la app o juego. Esto puede detectarse e incluso provocar el baneo de tu cuenta del juego.\n\n¿Seguro que quieres activarlo? Te recomendamos preguntar a la comunidad antes de decidir.',
+  got_warn_ok:    'Activar de todos modos',
+  got_warn_link:  'Comunidad COPG en Telegram',
+
+  /* Toggle info popups */
+  info_aria:           '¿Qué es esto?',
+  info_ok:             'Entendido',
+  info_withcpu_title:  'Con suplantación de CPU',
+  info_withcpu_msg:    'Además de falsear el modelo del dispositivo, esto también falsea los detalles del procesador (CPU) de tu teléfono para esta app. Actívalo para juegos que comprueban el chipset. Déjalo desactivado (por defecto) y la suplantación de CPU queda bloqueada — lo que prefieren las apps bancarias y sensibles.',
+  info_got_title:      'GOT Hooking',
+  info_got_msg:        'Una forma más profunda y agresiva de aplicar la suplantación desde dentro de la memoria de la app. Más potente pero más arriesgada: puede detectarse e incluso provocar el baneo de una cuenta de juego. Actívala solo si sabes que la necesitas.',
+  info_dnd_title:      'No molestar',
+  info_dnd_msg:        'Silencia llamadas y notificaciones mientras estás en este juego, para que nada interrumpa tu partida. Tu ajuste normal vuelve al salir.',
+  info_dab_title:      'Desactivar brillo automático',
+  info_dab_msg:        'Evita que la pantalla se atenúe y se ilumine sola mientras juegas, manteniendo el brillo que fijaste. Se restaura automáticamente al salir del juego.',
+  info_kso_title:      'Mantener pantalla encendida',
+  info_kso_msg:        'Mantiene la pantalla activa mientras este juego está abierto, aunque no la toques — sin apagones a mitad de la partida. Tu tiempo de espera normal vuelve al salir.',
+  info_nolog_title:    'Desactivar registro',
+  info_nolog_msg:      'Pausa el recolector de registros del sistema mientras juegas para liberar algo de CPU y almacenamiento. Se reactiva solo al salir del juego.',
+
+  /* Buttons */
+  btn_cancel: 'Cancelar',
+  btn_save:   'Guardar',
+  btn_delete: 'Eliminar',
+
+  /* Validation messages */
+  msg_required:    'Obligatorio',
+  msg_duplicate:   'Duplicado',
+  msg_dup_device:  'Ya existe un dispositivo con este nombre',
+  msg_dup_model:   'Ya existe un dispositivo con este modelo',
+  msg_pick_device: 'Selecciona un dispositivo',
+  msg_dup_pkg:     'Este paquete ya existe en',
+
+  /* Confirm delete */
+  confirm_del_device_title:  '¿Eliminar dispositivo?',
+  confirm_del_package_title: '¿Eliminar paquete?',
+
+  /* Toasts — CRUD */
+  toast_device_added:    'Dispositivo añadido',
+  toast_device_saved:    'Dispositivo guardado',
+  toast_device_deleted:  'Dispositivo eliminado',
+  toast_package_added:   'Paquete añadido',
+  toast_package_saved:   'Paquete guardado',
+  toast_package_deleted: 'Paquete eliminado',
+  toast_preview_only:    'Solo vista previa — no guardado en el dispositivo',
+  toast_save_failed:     'Error al guardar',
+});

--- a/webroot/js/lang/id.js
+++ b/webroot/js/lang/id.js
@@ -1,0 +1,269 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   id.js — Bahasa Indonesia (Indonesian)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+I18N.register('id', {
+  _meta: { name: 'Indonesia', flag: '🇮🇩', dir: 'ltr' },
+
+  /* Hero */
+  hero_module_id: 'Modul Zygisk',
+  hero_sub:       'Pemalsuan Perangkat & Aplikasi Tingkat Lanjut',
+  status_active:   'Aktif',
+  status_inactive: 'Nonaktif',
+
+  /* Section labels */
+  label_quick_stats: 'Statistik Cepat',
+  label_system:      'Sistem',
+  label_tools:       'Alat',
+  label_appearance:  'Tampilan',
+  label_developer:   'Pengembang',
+  label_about:       'Tentang',
+
+  /* Quick stats */
+  stat_devices:  'Perangkat',
+  stat_packages: 'Paket',
+
+  /* System rows */
+  sys_android: 'Versi Android',
+  sys_abi:     'ABI',
+  sys_zygisk:  'Varian Zygisk',
+  sys_root_version: 'Versi Root',
+  sys_kernel:  'Versi Kernel',
+
+  /* Console */
+  console_open:    'Buka Konsol',
+  console_title:   'Konsol',
+  console_logcat:  'Logcat',
+  console_clear:   'Bersihkan',
+  console_copy:    'Salin',
+  console_cmd_ph:  'Ketik perintah shell…',
+  console_copied:  'Disalin ke papan klip',
+  console_copy_fail: 'Salin tidak tersedia di sini',
+  console_cleared: 'Konsol dibersihkan',
+  console_save:      'Simpan',
+  console_saved:     'Log disimpan ke Download/COPG/LOGS',
+  console_saved_dl:  'Log diunduh',
+  console_save_empty:'Tidak ada yang disimpan',
+  console_save_fail: 'Gagal menyimpan log',
+
+  /* Page headers */
+  page_library:  'Pustaka',
+  page_settings: 'Pengaturan',
+
+  /* Library tabs + search */
+  tab_devices:     'Perangkat',
+  tab_packages:    'Paket',
+  search_devices:  'Cari perangkat…',
+  search_packages: 'Cari paket…',
+  empty_devices:   'Tidak ada perangkat',
+  empty_packages:  'Tidak ada paket',
+
+  /* Settings rows */
+  set_theme:        'Tema',
+  set_language:     'Bahasa',
+  set_debug:        'Log Debug',
+
+  /* Theme hints */
+  theme_auto:   'Otomatis',
+  theme_dark:   'Gelap',
+  theme_light:  'Terang',
+  theme_amoled: 'AMOLED',
+
+  /* Sheets */
+  sheet_theme_title: 'Tema',
+  sheet_lang_title:  'Bahasa',
+  theme_opt_auto:   'Otomatis (Sistem)',
+  theme_opt_dark:   'Gelap',
+  theme_opt_light:  'Terang',
+  theme_opt_amoled: 'AMOLED Hitam',
+
+  /* About */
+  about_module:  'Modul COPG',
+  about_version: 'Versi',
+  about_build:   'Tanggal Build',
+  about_vcode:   'Kode Versi',
+  about_author:  'Pembuat',
+  about_license: 'Lisensi',
+  about_desc:    'Modul Zygisk yang memalsukan perangkatmu — dan opsional CPU-nya — per game atau aplikasi, membuka FPS lebih tinggi, grafik lebih baik, dan fitur premium yang biasanya terkunci untuk ponsel tertentu. Tambah atau hapus aplikasi kapan saja dari WebUI ini, tanpa perlu reboot.',
+
+  /* Nav */
+  nav_home:     'Beranda',
+  nav_library:  'Pustaka',
+  nav_settings: 'Pengaturan',
+
+  /* Toasts */
+  toast_console:   'Konsol — segera hadir',
+  toast_debug_on:  'Log debug diaktifkan',
+  toast_debug_off: 'Log debug dinonaktifkan',
+  status_connected: 'Terhubung',
+  status_offline:   'Luring',
+
+  /* Library — add buttons & card meta */
+  add_device:   'Tambah Perangkat',
+  add_package:  'Tambah Paket',
+  add_short:    'Tambah',
+  act_edit:     'Edit',
+  act_delete:   'Hapus',
+  dev_model:    'Model',
+  dev_games:    'game',
+  dev_apps:     'aplikasi',
+  badge_installed: 'Terpasang',
+  preview_unsaved: 'Mode pratinjau — perubahan tidak disimpan ke perangkat.',
+
+  /* System — root */
+  sys_root: 'Root',
+
+  /* Sort + filter */
+  sort_title:     'Urutkan',
+  sort_default:   'Bawaan',
+  sort_name:      'Nama (A→Z)',
+  sort_name_za:   'Nama (Z→A)',
+  sort_apps:      'Jumlah aplikasi',
+  sort_brand:     'Merek',
+  sort_device:    'Perangkat',
+  sort_type:      'Tipe',
+  sort_installed: 'Terpasang dulu',
+  filter_all:      'Semua',
+  filter_user:     'Pengguna',
+  filter_system:   'Sistem',
+  filter_installed:'Terpasang',
+  filter_blocked:  'Diblokir',
+  filter_cpu_only: 'CPU',
+
+  /* App picker */
+  pick_from_installed: 'Pilih dari aplikasi terpasang',
+  picker_title:   'Aplikasi Terpasang',
+  picker_search:  'Cari aplikasi…',
+  picker_empty:   'Tidak ada aplikasi terpasang',
+  picker_no_results: 'Aplikasi tidak ditemukan',
+  picker_preview: 'Mode pratinjau — pasang di perangkat untuk melihat aplikasi',
+  toast_picker_unavailable: 'Pemilih aplikasi tidak tersedia di sini',
+
+  /* Backup & Sync */
+  lib_backup:           'Cadangkan & Sinkron',
+  backup_title:         'Cadangkan & Sinkron',
+  backup_intro:         'Cadangkan perangkat & paketmu, pulihkan cadangan sebelumnya, atau sinkronkan konfigurasi terbaru dari GitHub.',
+  backup_export:        'Ekspor cadangan',
+  backup_export_sub:    'Simpan data saat ini ke Download',
+  backup_import:        'Impor & pulihkan',
+  backup_import_sub:    'Pulihkan data dari cadangan',
+  backup_empty:         'Tidak ada cadangan di Downloads/COPG',
+  backup_from_file:     'Impor dari file…',
+  backup_confirm_title: 'Pulihkan cadangan?',
+  backup_confirm_msg:   'Ini akan menimpa perangkat & paketmu saat ini dengan:',
+  backup_restore:       'Pulihkan',
+  toast_backup_ok:      'Cadangan disimpan',
+  toast_backup_fail:    'Pencadangan gagal',
+  toast_restore_ok:     'Cadangan dipulihkan',
+  toast_restore_fail:   'Pemulihan gagal',
+  toast_invalid_json:   'Bukan file JSON yang valid',
+
+  /* Import type chooser */
+  backup_kind_title:       'File jenis apa ini?',
+  backup_kind_config:      'Perangkat & Paket',
+  backup_kind_config_sub:  'Konfigurasi perangkat & paket (COPG.json)',
+  backup_kind_list:        'Nama Tampilan',
+  backup_kind_list_sub:    'Nama tampilan paket (list.json)',
+  backup_kind_detected:    'terdeteksi',
+
+  /* Sync from GitHub */
+  backup_sync:        'Sinkron dari GitHub',
+  backup_sync_sub:    'Ambil konfigurasi terbaru dari repo',
+  toast_sync_ok:      'Tersinkron dari GitHub',
+  toast_sync_fail:    'Sinkron gagal — periksa koneksimu',
+  toast_sync_preview: 'Sinkron hanya bekerja di perangkat',
+
+  /* Package types (chips) */
+  pkgtype_device:   'Perangkat',
+  pkgtype_cpu_only: 'Palsukan CPU',
+  pkgtype_blocked:  'Blokir Palsu CPU',
+
+  /* Package tags (chips) */
+  tag_withcpu:  'Dengan CPU',
+  tag_got:      'GOT',
+  tag_dnd:      'DND',
+  tag_dab:      'Cerah Auto',
+  tag_kso:      'Layar Nyala',
+  tag_nolog:    'Tanpa Log',
+
+  /* Device modal */
+  dev_add_title:      'Tambah Perangkat',
+  dev_edit_title:     'Edit Perangkat',
+  dev_f_name:         'Nama Perangkat',
+  dev_f_brand:        'Merek',
+  dev_f_model:        'Model',
+  dev_f_manufacturer: 'Produsen',
+  dev_f_fingerprint:  'Fingerprint',
+  dev_f_android:      'Versi Android',
+  dev_f_sdk:          'SDK Int',
+  dev_f_serial:       'Nomor Seri',
+  opt_optional:       '(opsional)',
+  serial_gen:         'Buat',
+  info_sdk_title:     'SDK Int',
+  info_sdk_msg:       'Level SDK dan Versi Android adalah pasangan yang cocok — terisi otomatis dari Versi Android. Jika kamu menyetel SDK yang tidak cocok, sebagian aplikasi mendeteksi ketidakcocokan dan crash. Edit manual hanya untuk versi Android baru yang belum dikenal modul.',
+
+  /* Package modal */
+  pkg_add_title:  'Tambah Paket',
+  pkg_edit_title: 'Edit Paket',
+  pkg_f_package:  'Nama Paket',
+  pkg_f_name:     'Nama Tampilan',
+  pkg_f_type:     'Tipe',
+  pkg_f_device:   'Profil Perangkat',
+  pkg_no_devices: 'Tidak ada perangkat — tambah dulu',
+  pkg_sec_spoofing: 'Pemalsuan',
+  pkg_sec_tweaks:   'Penyesuaian',
+  pkg_t_withcpu:  'Dengan Pemalsuan CPU',
+  pkg_t_got:      'GOT Hooking',
+  pkg_t_dnd:      'Jangan Ganggu',
+  pkg_t_dab:      'Matikan Kecerahan Otomatis',
+  pkg_t_kso:      'Biarkan Layar Menyala',
+  pkg_t_nolog:    'Matikan Logging',
+
+  /* GOT Hooking warning */
+  got_warn_title: 'Aktifkan GOT Hooking?',
+  got_warn_msg:   'GOT Hooking membuat modul tetap berada di memori aplikasi atau game. Ini bisa terdeteksi dan bahkan dapat membuat akun game-mu diblokir.\n\nYakin ingin mengaktifkannya? Kami sarankan bertanya ke komunitas sebelum memutuskan.',
+  got_warn_ok:    'Tetap aktifkan',
+  got_warn_link:  'Komunitas COPG di Telegram',
+
+  /* Toggle info popups */
+  info_aria:           'Apa ini?',
+  info_ok:             'Mengerti',
+  info_withcpu_title:  'Dengan Pemalsuan CPU',
+  info_withcpu_msg:    'Selain memalsukan model perangkat, ini juga memalsukan detail prosesor (CPU) ponselmu untuk aplikasi ini. Aktifkan untuk game yang memeriksa chipset. Biarkan mati (bawaan) dan pemalsuan CPU tetap diblokir — yang disukai aplikasi perbankan dan sensitif.',
+  info_got_title:      'GOT Hooking',
+  info_got_msg:        'Cara yang lebih dalam dan agresif untuk menerapkan pemalsuan dari dalam memori aplikasi. Lebih kuat tapi lebih berisiko: bisa terdeteksi dan bahkan membuat akun game diblokir. Aktifkan hanya jika kamu yakin membutuhkannya.',
+  info_dnd_title:      'Jangan Ganggu',
+  info_dnd_msg:        'Membisukan panggilan dan notifikasi selama kamu di game ini, agar tidak ada yang mengganggu pertandinganmu. Pengaturan normalmu kembali saat keluar.',
+  info_dab_title:      'Matikan Kecerahan Otomatis',
+  info_dab_msg:        'Mencegah layar meredup dan menerangi sendiri saat bermain, sehingga kecerahan tetap sesuai setelanmu. Dipulihkan otomatis saat keluar game.',
+  info_kso_title:      'Biarkan Layar Menyala',
+  info_kso_msg:        'Menjaga layar tetap menyala selama game ini terbuka, meski tidak disentuh — tidak ada lagi layar mati di tengah pertandingan. Batas waktu normalmu kembali saat keluar.',
+  info_nolog_title:    'Matikan Logging',
+  info_nolog_msg:      'Menjeda pengumpul log sistem saat bermain untuk menghemat sedikit CPU dan penyimpanan. Menyala lagi otomatis saat keluar game.',
+
+  /* Buttons */
+  btn_cancel: 'Batal',
+  btn_save:   'Simpan',
+  btn_delete: 'Hapus',
+
+  /* Validation messages */
+  msg_required:    'Wajib',
+  msg_duplicate:   'Duplikat',
+  msg_dup_device:  'Perangkat dengan nama ini sudah ada',
+  msg_dup_model:   'Perangkat dengan model ini sudah ada',
+  msg_pick_device: 'Pilih perangkat',
+  msg_dup_pkg:     'Paket ini sudah ada di',
+
+  /* Confirm delete */
+  confirm_del_device_title:  'Hapus Perangkat?',
+  confirm_del_package_title: 'Hapus Paket?',
+
+  /* Toasts — CRUD */
+  toast_device_added:    'Perangkat ditambahkan',
+  toast_device_saved:    'Perangkat disimpan',
+  toast_device_deleted:  'Perangkat dihapus',
+  toast_package_added:   'Paket ditambahkan',
+  toast_package_saved:   'Paket disimpan',
+  toast_package_deleted: 'Paket dihapus',
+  toast_preview_only:    'Hanya pratinjau — tidak disimpan ke perangkat',
+  toast_save_failed:     'Gagal menyimpan',
+});

--- a/webroot/js/lang/th.js
+++ b/webroot/js/lang/th.js
@@ -1,0 +1,269 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   th.js — ไทย (Thai)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+I18N.register('th', {
+  _meta: { name: 'ไทย', flag: '🇹🇭', dir: 'ltr' },
+
+  /* Hero */
+  hero_module_id: 'โมดูล Zygisk',
+  hero_sub:       'การปลอมแปลงอุปกรณ์และแอปขั้นสูง',
+  status_active:   'เปิดใช้งาน',
+  status_inactive: 'ปิดใช้งาน',
+
+  /* Section labels */
+  label_quick_stats: 'สถิติด่วน',
+  label_system:      'ระบบ',
+  label_tools:       'เครื่องมือ',
+  label_appearance:  'รูปลักษณ์',
+  label_developer:   'นักพัฒนา',
+  label_about:       'เกี่ยวกับ',
+
+  /* Quick stats */
+  stat_devices:  'อุปกรณ์',
+  stat_packages: 'แพ็กเกจ',
+
+  /* System rows */
+  sys_android: 'เวอร์ชัน Android',
+  sys_abi:     'ABI',
+  sys_zygisk:  'ชนิด Zygisk',
+  sys_root_version: 'เวอร์ชัน Root',
+  sys_kernel:  'เวอร์ชันเคอร์เนล',
+
+  /* Console */
+  console_open:    'เปิดคอนโซล',
+  console_title:   'คอนโซล',
+  console_logcat:  'Logcat',
+  console_clear:   'ล้าง',
+  console_copy:    'คัดลอก',
+  console_cmd_ph:  'พิมพ์คำสั่งเชลล์…',
+  console_copied:  'คัดลอกไปยังคลิปบอร์ดแล้ว',
+  console_copy_fail: 'คัดลอกไม่ได้ที่นี่',
+  console_cleared: 'ล้างคอนโซลแล้ว',
+  console_save:      'บันทึก',
+  console_saved:     'บันทึกล็อกไปที่ Download/COPG/LOGS แล้ว',
+  console_saved_dl:  'ดาวน์โหลดล็อกแล้ว',
+  console_save_empty:'ไม่มีอะไรให้บันทึก',
+  console_save_fail: 'บันทึกล็อกล้มเหลว',
+
+  /* Page headers */
+  page_library:  'คลัง',
+  page_settings: 'การตั้งค่า',
+
+  /* Library tabs + search */
+  tab_devices:     'อุปกรณ์',
+  tab_packages:    'แพ็กเกจ',
+  search_devices:  'ค้นหาอุปกรณ์…',
+  search_packages: 'ค้นหาแพ็กเกจ…',
+  empty_devices:   'ไม่พบอุปกรณ์',
+  empty_packages:  'ไม่พบแพ็กเกจ',
+
+  /* Settings rows */
+  set_theme:        'ธีม',
+  set_language:     'ภาษา',
+  set_debug:        'ล็อกดีบัก',
+
+  /* Theme hints */
+  theme_auto:   'อัตโนมัติ',
+  theme_dark:   'มืด',
+  theme_light:  'สว่าง',
+  theme_amoled: 'AMOLED',
+
+  /* Sheets */
+  sheet_theme_title: 'ธีม',
+  sheet_lang_title:  'ภาษา',
+  theme_opt_auto:   'อัตโนมัติ (ระบบ)',
+  theme_opt_dark:   'มืด',
+  theme_opt_light:  'สว่าง',
+  theme_opt_amoled: 'ดำ AMOLED',
+
+  /* About */
+  about_module:  'โมดูล COPG',
+  about_version: 'เวอร์ชัน',
+  about_build:   'วันที่สร้าง',
+  about_vcode:   'รหัสเวอร์ชัน',
+  about_author:  'ผู้พัฒนา',
+  about_license: 'สัญญาอนุญาต',
+  about_desc:    'โมดูล Zygisk ที่ปลอมแปลงอุปกรณ์ของคุณ — และปลอม CPU ได้ตามต้องการ — แยกตามเกมหรือแอป เพื่อปลดล็อก FPS ที่สูงขึ้น กราฟิกที่ดีขึ้น และฟีเจอร์พรีเมียมที่ปกติจำกัดเฉพาะบางรุ่น เพิ่มหรือลบแอปได้ทุกเมื่อจาก WebUI นี้ โดยไม่ต้องรีบูต',
+
+  /* Nav */
+  nav_home:     'หน้าแรก',
+  nav_library:  'คลัง',
+  nav_settings: 'การตั้งค่า',
+
+  /* Toasts */
+  toast_console:   'คอนโซล — เร็ว ๆ นี้',
+  toast_debug_on:  'เปิดล็อกดีบักแล้ว',
+  toast_debug_off: 'ปิดล็อกดีบักแล้ว',
+  status_connected: 'เชื่อมต่อแล้ว',
+  status_offline:   'ออฟไลน์',
+
+  /* Library — add buttons & card meta */
+  add_device:   'เพิ่มอุปกรณ์',
+  add_package:  'เพิ่มแพ็กเกจ',
+  add_short:    'เพิ่ม',
+  act_edit:     'แก้ไข',
+  act_delete:   'ลบ',
+  dev_model:    'รุ่น',
+  dev_games:    'เกม',
+  dev_apps:     'แอป',
+  badge_installed: 'ติดตั้งแล้ว',
+  preview_unsaved: 'โหมดดูตัวอย่าง — การเปลี่ยนแปลงไม่ถูกบันทึกลงอุปกรณ์',
+
+  /* System — root */
+  sys_root: 'Root',
+
+  /* Sort + filter */
+  sort_title:     'เรียงตาม',
+  sort_default:   'ค่าเริ่มต้น',
+  sort_name:      'ชื่อ (A→Z)',
+  sort_name_za:   'ชื่อ (Z→A)',
+  sort_apps:      'จำนวนแอป',
+  sort_brand:     'แบรนด์',
+  sort_device:    'อุปกรณ์',
+  sort_type:      'ประเภท',
+  sort_installed: 'ติดตั้งแล้วก่อน',
+  filter_all:      'ทั้งหมด',
+  filter_user:     'ผู้ใช้',
+  filter_system:   'ระบบ',
+  filter_installed:'ติดตั้งแล้ว',
+  filter_blocked:  'ถูกบล็อก',
+  filter_cpu_only: 'CPU',
+
+  /* App picker */
+  pick_from_installed: 'เลือกจากแอปที่ติดตั้ง',
+  picker_title:   'แอปที่ติดตั้ง',
+  picker_search:  'ค้นหาแอป…',
+  picker_empty:   'ไม่พบแอปที่ติดตั้ง',
+  picker_no_results: 'ไม่พบแอป',
+  picker_preview: 'โหมดดูตัวอย่าง — ติดตั้งบนอุปกรณ์เพื่อดูรายการแอป',
+  toast_picker_unavailable: 'ตัวเลือกแอปใช้ไม่ได้ที่นี่',
+
+  /* Backup & Sync */
+  lib_backup:           'สำรองและซิงค์',
+  backup_title:         'สำรองและซิงค์',
+  backup_intro:         'สำรองอุปกรณ์และแพ็กเกจของคุณ คืนค่าจากข้อมูลสำรองก่อนหน้า หรือซิงค์การตั้งค่าล่าสุดจาก GitHub',
+  backup_export:        'ส่งออกข้อมูลสำรอง',
+  backup_export_sub:    'บันทึกข้อมูลปัจจุบันไปยังดาวน์โหลด',
+  backup_import:        'นำเข้าและคืนค่า',
+  backup_import_sub:    'คืนค่าข้อมูลจากข้อมูลสำรอง',
+  backup_empty:         'ไม่พบข้อมูลสำรองใน Downloads/COPG',
+  backup_from_file:     'นำเข้าจากไฟล์…',
+  backup_confirm_title: 'คืนค่าข้อมูลสำรอง?',
+  backup_confirm_msg:   'การทำเช่นนี้จะเขียนทับอุปกรณ์และแพ็กเกจปัจจุบันด้วย:',
+  backup_restore:       'คืนค่า',
+  toast_backup_ok:      'บันทึกข้อมูลสำรองแล้ว',
+  toast_backup_fail:    'สำรองข้อมูลล้มเหลว',
+  toast_restore_ok:     'คืนค่าข้อมูลสำรองแล้ว',
+  toast_restore_fail:   'คืนค่าล้มเหลว',
+  toast_invalid_json:   'ไม่ใช่ไฟล์ JSON ที่ถูกต้อง',
+
+  /* Import type chooser */
+  backup_kind_title:       'ไฟล์นี้เป็นชนิดใด?',
+  backup_kind_config:      'อุปกรณ์และแพ็กเกจ',
+  backup_kind_config_sub:  'การตั้งค่าอุปกรณ์และแพ็กเกจ (COPG.json)',
+  backup_kind_list:        'ชื่อที่แสดง',
+  backup_kind_list_sub:    'ชื่อที่แสดงของแพ็กเกจ (list.json)',
+  backup_kind_detected:    'ตรวจพบ',
+
+  /* Sync from GitHub */
+  backup_sync:        'ซิงค์จาก GitHub',
+  backup_sync_sub:    'ดึงการตั้งค่าล่าสุดจากที่เก็บ',
+  toast_sync_ok:      'ซิงค์จาก GitHub แล้ว',
+  toast_sync_fail:    'ซิงค์ล้มเหลว — ตรวจสอบการเชื่อมต่อ',
+  toast_sync_preview: 'การซิงค์ใช้ได้บนอุปกรณ์เท่านั้น',
+
+  /* Package types (chips) */
+  pkgtype_device:   'อุปกรณ์',
+  pkgtype_cpu_only: 'ปลอม CPU',
+  pkgtype_blocked:  'บล็อกการปลอม CPU',
+
+  /* Package tags (chips) */
+  tag_withcpu:  'พร้อม CPU',
+  tag_got:      'GOT',
+  tag_dnd:      'ห้ามรบกวน',
+  tag_dab:      'สว่างอัตโนมัติ',
+  tag_kso:      'จอติด',
+  tag_nolog:    'ไม่บันทึก',
+
+  /* Device modal */
+  dev_add_title:      'เพิ่มอุปกรณ์',
+  dev_edit_title:     'แก้ไขอุปกรณ์',
+  dev_f_name:         'ชื่ออุปกรณ์',
+  dev_f_brand:        'แบรนด์',
+  dev_f_model:        'รุ่น',
+  dev_f_manufacturer: 'ผู้ผลิต',
+  dev_f_fingerprint:  'ลายนิ้วมือ (fingerprint)',
+  dev_f_android:      'เวอร์ชัน Android',
+  dev_f_sdk:          'SDK Int',
+  dev_f_serial:       'หมายเลขซีเรียล',
+  opt_optional:       '(ไม่บังคับ)',
+  serial_gen:         'สร้าง',
+  info_sdk_title:     'SDK Int',
+  info_sdk_msg:       'ระดับ SDK และเวอร์ชัน Android เป็นคู่ที่ต้องตรงกัน — จะกรอกอัตโนมัติจากเวอร์ชัน Android หากตั้ง SDK ที่ไม่ตรงกัน บางแอปจะตรวจพบความไม่ตรงและขัดข้อง แก้ไขด้วยตนเองเฉพาะเวอร์ชัน Android ใหม่ที่โมดูลยังไม่รู้จักเท่านั้น',
+
+  /* Package modal */
+  pkg_add_title:  'เพิ่มแพ็กเกจ',
+  pkg_edit_title: 'แก้ไขแพ็กเกจ',
+  pkg_f_package:  'ชื่อแพ็กเกจ',
+  pkg_f_name:     'ชื่อที่แสดง',
+  pkg_f_type:     'ประเภท',
+  pkg_f_device:   'โปรไฟล์อุปกรณ์',
+  pkg_no_devices: 'ไม่มีอุปกรณ์ — เพิ่มก่อน',
+  pkg_sec_spoofing: 'การปลอมแปลง',
+  pkg_sec_tweaks:   'การปรับแต่ง',
+  pkg_t_withcpu:  'ปลอม CPU ด้วย',
+  pkg_t_got:      'GOT Hooking',
+  pkg_t_dnd:      'ห้ามรบกวน',
+  pkg_t_dab:      'ปิดความสว่างอัตโนมัติ',
+  pkg_t_kso:      'เปิดหน้าจอค้างไว้',
+  pkg_t_nolog:    'ปิดการบันทึกล็อก',
+
+  /* GOT Hooking warning */
+  got_warn_title: 'เปิด GOT Hooking?',
+  got_warn_msg:   'GOT Hooking จะทำให้โมดูลคงอยู่ในหน่วยความจำของแอปหรือเกม สิ่งนี้อาจถูกตรวจพบและอาจทำให้บัญชีเกมของคุณถูกแบนได้\n\nแน่ใจหรือไม่ว่าต้องการเปิด? เราแนะนำให้สอบถามชุมชนก่อนตัดสินใจ',
+  got_warn_ok:    'เปิดต่อไป',
+  got_warn_link:  'ชุมชน COPG บน Telegram',
+
+  /* Toggle info popups */
+  info_aria:           'นี่คืออะไร?',
+  info_ok:             'เข้าใจแล้ว',
+  info_withcpu_title:  'ปลอม CPU ด้วย',
+  info_withcpu_msg:    'นอกจากปลอมรุ่นอุปกรณ์แล้ว ยังปลอมรายละเอียดหน่วยประมวลผล (CPU) ของเครื่องสำหรับแอปนี้ด้วย เปิดสำหรับเกมที่ตรวจสอบชิปเซ็ต ปล่อยปิดไว้ (ค่าเริ่มต้น) การปลอม CPU จะถูกบล็อก — ซึ่งแอปธนาคารและแอปที่ละเอียดอ่อนชอบแบบนั้น',
+  info_got_title:      'GOT Hooking',
+  info_got_msg:        'วิธีที่ลึกและรุนแรงกว่าในการปลอมจากภายในหน่วยความจำของแอป แรงกว่าแต่เสี่ยงกว่า: อาจถูกตรวจพบและอาจทำให้บัญชีเกมถูกแบน เปิดเฉพาะเมื่อคุณรู้ว่าต้องใช้เท่านั้น',
+  info_dnd_title:      'ห้ามรบกวน',
+  info_dnd_msg:        'ปิดเสียงสายและการแจ้งเตือนขณะอยู่ในเกมนี้ เพื่อไม่ให้มีอะไรมารบกวนแมตช์ของคุณ การตั้งค่าปกติจะกลับมาเมื่อออก',
+  info_dab_title:      'ปิดความสว่างอัตโนมัติ',
+  info_dab_msg:        'หยุดไม่ให้หน้าจอหรี่และสว่างเองขณะเล่น เพื่อให้ความสว่างคงที่ตามที่ตั้งไว้ คืนค่าอัตโนมัติเมื่อออกจากเกม',
+  info_kso_title:      'เปิดหน้าจอค้างไว้',
+  info_kso_msg:        'เปิดหน้าจอค้างไว้ขณะเกมนี้เปิดอยู่ แม้ไม่ได้แตะ — ไม่มีจอดับกลางแมตช์อีกต่อไป เวลาหมดเวลาปกติจะกลับมาเมื่อออก',
+  info_nolog_title:    'ปิดการบันทึกล็อก',
+  info_nolog_msg:      'หยุดตัวเก็บล็อกระบบชั่วคราวขณะเล่นเพื่อประหยัด CPU และพื้นที่เล็กน้อย จะเปิดกลับเองเมื่อออกจากเกม',
+
+  /* Buttons */
+  btn_cancel: 'ยกเลิก',
+  btn_save:   'บันทึก',
+  btn_delete: 'ลบ',
+
+  /* Validation messages */
+  msg_required:    'จำเป็น',
+  msg_duplicate:   'ซ้ำ',
+  msg_dup_device:  'มีอุปกรณ์ชื่อนี้อยู่แล้ว',
+  msg_dup_model:   'มีอุปกรณ์รุ่นนี้อยู่แล้ว',
+  msg_pick_device: 'เลือกอุปกรณ์',
+  msg_dup_pkg:     'แพ็กเกจนี้มีอยู่แล้วใน',
+
+  /* Confirm delete */
+  confirm_del_device_title:  'ลบอุปกรณ์?',
+  confirm_del_package_title: 'ลบแพ็กเกจ?',
+
+  /* Toasts — CRUD */
+  toast_device_added:    'เพิ่มอุปกรณ์แล้ว',
+  toast_device_saved:    'บันทึกอุปกรณ์แล้ว',
+  toast_device_deleted:  'ลบอุปกรณ์แล้ว',
+  toast_package_added:   'เพิ่มแพ็กเกจแล้ว',
+  toast_package_saved:   'บันทึกแพ็กเกจแล้ว',
+  toast_package_deleted: 'ลบแพ็กเกจแล้ว',
+  toast_preview_only:    'ดูตัวอย่างเท่านั้น — ไม่ได้บันทึกลงอุปกรณ์',
+  toast_save_failed:     'บันทึกล้มเหลว',
+});

--- a/webroot/js/lang/zh.js
+++ b/webroot/js/lang/zh.js
@@ -1,0 +1,269 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   zh.js — 中文 (Simplified Chinese)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+I18N.register('zh', {
+  _meta: { name: '中文', flag: '🇨🇳', dir: 'ltr' },
+
+  /* Hero */
+  hero_module_id: 'Zygisk 模块',
+  hero_sub:       '高级设备与应用伪装',
+  status_active:   '已启用',
+  status_inactive: '未启用',
+
+  /* Section labels */
+  label_quick_stats: '快速统计',
+  label_system:      '系统',
+  label_tools:       '工具',
+  label_appearance:  '外观',
+  label_developer:   '开发者',
+  label_about:       '关于',
+
+  /* Quick stats */
+  stat_devices:  '设备',
+  stat_packages: '应用包',
+
+  /* System rows */
+  sys_android: 'Android 版本',
+  sys_abi:     'ABI',
+  sys_zygisk:  'Zygisk 类型',
+  sys_root_version: 'Root 版本',
+  sys_kernel:  '内核版本',
+
+  /* Console */
+  console_open:    '打开控制台',
+  console_title:   '控制台',
+  console_logcat:  'Logcat',
+  console_clear:   '清除',
+  console_copy:    '复制',
+  console_cmd_ph:  '输入 shell 命令…',
+  console_copied:  '已复制到剪贴板',
+  console_copy_fail: '此处无法复制',
+  console_cleared: '控制台已清除',
+  console_save:      '保存',
+  console_saved:     '日志已保存到 Download/COPG/LOGS',
+  console_saved_dl:  '日志已下载',
+  console_save_empty:'没有可保存的内容',
+  console_save_fail: '保存日志失败',
+
+  /* Page headers */
+  page_library:  '库',
+  page_settings: '设置',
+
+  /* Library tabs + search */
+  tab_devices:     '设备',
+  tab_packages:    '应用包',
+  search_devices:  '搜索设备…',
+  search_packages: '搜索应用包…',
+  empty_devices:   '未找到设备',
+  empty_packages:  '未找到应用包',
+
+  /* Settings rows */
+  set_theme:        '主题',
+  set_language:     '语言',
+  set_debug:        '调试日志',
+
+  /* Theme hints */
+  theme_auto:   '自动',
+  theme_dark:   '深色',
+  theme_light:  '浅色',
+  theme_amoled: 'AMOLED',
+
+  /* Sheets */
+  sheet_theme_title: '主题',
+  sheet_lang_title:  '语言',
+  theme_opt_auto:   '自动（系统）',
+  theme_opt_dark:   '深色',
+  theme_opt_light:  '浅色',
+  theme_opt_amoled: 'AMOLED 纯黑',
+
+  /* About */
+  about_module:  'COPG 模块',
+  about_version: '版本',
+  about_build:   '构建日期',
+  about_vcode:   '版本号',
+  about_author:  '作者',
+  about_license: '许可证',
+  about_desc:    '一个 Zygisk 模块，可按游戏或应用伪装你的设备——并可选伪装其 CPU，从而解锁更高帧率、更好画质，以及通常仅限特定机型的高级功能。随时可从此 WebUI 添加或移除应用，无需重启。',
+
+  /* Nav */
+  nav_home:     '主页',
+  nav_library:  '库',
+  nav_settings: '设置',
+
+  /* Toasts */
+  toast_console:   '控制台——即将推出',
+  toast_debug_on:  '已启用调试日志',
+  toast_debug_off: '已禁用调试日志',
+  status_connected: '已连接',
+  status_offline:   '离线',
+
+  /* Library — add buttons & card meta */
+  add_device:   '添加设备',
+  add_package:  '添加应用包',
+  add_short:    '添加',
+  act_edit:     '编辑',
+  act_delete:   '删除',
+  dev_model:    '型号',
+  dev_games:    '游戏',
+  dev_apps:     '应用',
+  badge_installed: '已安装',
+  preview_unsaved: '预览模式——更改不会保存到设备。',
+
+  /* System — root */
+  sys_root: 'Root',
+
+  /* Sort + filter */
+  sort_title:     '排序方式',
+  sort_default:   '默认',
+  sort_name:      '名称 (A→Z)',
+  sort_name_za:   '名称 (Z→A)',
+  sort_apps:      '应用数量',
+  sort_brand:     '品牌',
+  sort_device:    '设备',
+  sort_type:      '类型',
+  sort_installed: '已安装优先',
+  filter_all:      '全部',
+  filter_user:     '用户',
+  filter_system:   '系统',
+  filter_installed:'已安装',
+  filter_blocked:  '已屏蔽',
+  filter_cpu_only: 'CPU',
+
+  /* App picker */
+  pick_from_installed: '从已安装应用中选择',
+  picker_title:   '已安装应用',
+  picker_search:  '搜索应用…',
+  picker_empty:   '未找到已安装应用',
+  picker_no_results: '未找到应用',
+  picker_preview: '预览模式——请在设备上安装以列出应用',
+  toast_picker_unavailable: '此处无法使用应用选择器',
+
+  /* Backup & Sync */
+  lib_backup:           '备份与同步',
+  backup_title:         '备份与同步',
+  backup_intro:         '备份你的设备和应用包，恢复以前的备份，或从 GitHub 同步最新配置。',
+  backup_export:        '导出备份',
+  backup_export_sub:    '将当前数据保存到下载',
+  backup_import:        '导入并恢复',
+  backup_import_sub:    '从备份恢复数据',
+  backup_empty:         '在 Downloads/COPG 中未找到备份',
+  backup_from_file:     '从文件导入…',
+  backup_confirm_title: '恢复备份？',
+  backup_confirm_msg:   '这将用以下内容覆盖你当前的设备和应用包：',
+  backup_restore:       '恢复',
+  toast_backup_ok:      '备份已保存',
+  toast_backup_fail:    '备份失败',
+  toast_restore_ok:     '备份已恢复',
+  toast_restore_fail:   '恢复失败',
+  toast_invalid_json:   '不是有效的 JSON 文件',
+
+  /* Import type chooser */
+  backup_kind_title:       '这是什么类型的文件？',
+  backup_kind_config:      '设备与应用包',
+  backup_kind_config_sub:  '设备与应用包配置 (COPG.json)',
+  backup_kind_list:        '显示名称',
+  backup_kind_list_sub:    '应用包显示名称 (list.json)',
+  backup_kind_detected:    '已检测',
+
+  /* Sync from GitHub */
+  backup_sync:        '从 GitHub 同步',
+  backup_sync_sub:    '从仓库获取最新配置',
+  toast_sync_ok:      '已从 GitHub 同步',
+  toast_sync_fail:    '同步失败——请检查网络连接',
+  toast_sync_preview: '同步仅在设备上可用',
+
+  /* Package types (chips) */
+  pkgtype_device:   '设备',
+  pkgtype_cpu_only: 'CPU 伪装',
+  pkgtype_blocked:  '屏蔽 CPU 伪装',
+
+  /* Package tags (chips) */
+  tag_withcpu:  '含 CPU',
+  tag_got:      'GOT',
+  tag_dnd:      '勿扰',
+  tag_dab:      '自动亮度',
+  tag_kso:      '屏幕常亮',
+  tag_nolog:    '无日志',
+
+  /* Device modal */
+  dev_add_title:      '添加设备',
+  dev_edit_title:     '编辑设备',
+  dev_f_name:         '设备名称',
+  dev_f_brand:        '品牌',
+  dev_f_model:        '型号',
+  dev_f_manufacturer: '制造商',
+  dev_f_fingerprint:  '指纹 (fingerprint)',
+  dev_f_android:      'Android 版本',
+  dev_f_sdk:          'SDK Int',
+  dev_f_serial:       '序列号',
+  opt_optional:       '（可选）',
+  serial_gen:         '生成',
+  info_sdk_title:     'SDK Int',
+  info_sdk_msg:       'SDK 级别与 Android 版本是配对的——它会根据 Android 版本自动填充。如果设置了与版本不匹配的 SDK，部分应用会检测到不一致并崩溃。仅当模块尚不认识某个全新 Android 版本时才手动编辑。',
+
+  /* Package modal */
+  pkg_add_title:  '添加应用包',
+  pkg_edit_title: '编辑应用包',
+  pkg_f_package:  '包名',
+  pkg_f_name:     '显示名称',
+  pkg_f_type:     '类型',
+  pkg_f_device:   '设备配置',
+  pkg_no_devices: '没有设备——请先添加一个',
+  pkg_sec_spoofing: '伪装',
+  pkg_sec_tweaks:   '微调',
+  pkg_t_withcpu:  '伪装 CPU',
+  pkg_t_got:      'GOT Hooking',
+  pkg_t_dnd:      '勿扰模式',
+  pkg_t_dab:      '关闭自动亮度',
+  pkg_t_kso:      '保持屏幕常亮',
+  pkg_t_nolog:    '关闭日志记录',
+
+  /* GOT Hooking warning */
+  got_warn_title: '启用 GOT Hooking？',
+  got_warn_msg:   'GOT Hooking 会让模块常驻于应用或游戏的内存中。这可能被检测到，甚至可能导致你的游戏账号被封。\n\n确定要启用吗？建议在决定前先咨询社区。',
+  got_warn_ok:    '仍然启用',
+  got_warn_link:  'Telegram 上的 COPG 社区',
+
+  /* Toggle info popups */
+  info_aria:           '这是什么？',
+  info_ok:             '知道了',
+  info_withcpu_title:  '伪装 CPU',
+  info_withcpu_msg:    '在伪装设备型号之外，这还会为此应用伪装手机的处理器 (CPU) 信息。对于会检查芯片的游戏请开启。保持关闭（默认）则 CPU 伪装被屏蔽——银行和敏感应用更喜欢这样。',
+  info_got_title:      'GOT Hooking',
+  info_got_msg:        '一种更深入、更激进的方式，从应用内存内部应用伪装。更强但更冒险：可能被检测到，甚至可能导致游戏账号被封。仅在你确定需要时才启用。',
+  info_dnd_title:      '勿扰模式',
+  info_dnd_msg:        '在你玩此游戏期间静音来电和通知，让任何东西都不会打断你的对局。退出后恢复你的常规设置。',
+  info_dab_title:      '关闭自动亮度',
+  info_dab_msg:        '游戏时阻止屏幕自动变暗或变亮，让亮度保持在你设定的值。退出游戏后自动恢复。',
+  info_kso_title:      '保持屏幕常亮',
+  info_kso_msg:        '此游戏打开期间保持屏幕常亮，即使你不触碰——不再在对局中途熄屏。退出后恢复你的常规超时。',
+  info_nolog_title:    '关闭日志记录',
+  info_nolog_msg:      '游戏时暂停系统日志收集器，以释放少量 CPU 和存储。退出游戏后自动重新开启。',
+
+  /* Buttons */
+  btn_cancel: '取消',
+  btn_save:   '保存',
+  btn_delete: '删除',
+
+  /* Validation messages */
+  msg_required:    '必填',
+  msg_duplicate:   '重复',
+  msg_dup_device:  '已存在同名设备',
+  msg_dup_model:   '已存在同型号设备',
+  msg_pick_device: '请选择设备',
+  msg_dup_pkg:     '此应用包已存在于',
+
+  /* Confirm delete */
+  confirm_del_device_title:  '删除设备？',
+  confirm_del_package_title: '删除应用包？',
+
+  /* Toasts — CRUD */
+  toast_device_added:    '已添加设备',
+  toast_device_saved:    '已保存设备',
+  toast_device_deleted:  '已删除设备',
+  toast_package_added:   '已添加应用包',
+  toast_package_saved:   '已保存应用包',
+  toast_package_deleted: '已删除应用包',
+  toast_preview_only:    '仅预览——未保存到设备',
+  toast_save_failed:     '保存失败',
+});


### PR DESCRIPTION
### WebUI
- **6 new languages** (203 keys each, full parity with English): **Arabic (RTL)**, German, Spanish, Indonesian, Thai, Chinese — joining English + Persian for **8 total**. Auto-listed in the language sheet; Arabic gets full RTL.
- Wired in `index.html`; technical terms (Zygisk, GOT, ABI, CPU, AMOLED, SDK, FPS, COPG) kept Latin.

### Changelog
- v5.0.0: updated language line (8 languages) + new icon/title note.
- Note added: only **English** and **Persian** are officially maintained going forward; other languages are community-driven (PRs welcome).