### PR TITLE
CI: bump actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -251,7 +251,7 @@ jobs:
           fi
 
       - name: Upload Module ZIP as Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: COPG
           path: ${{ env.ZIP_NAME }}


### PR DESCRIPTION
Bumps `actions/checkout@v4 → v5` and `actions/upload-artifact@v4 → v5` so they run on Node 24, clearing the Node 20 deprecation warning. `setup-java@v5` already on Node 24.