### PR TITLE
CI: upload-artifact v5 → v7 (real Node 24)

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -251,7 +251,7 @@ jobs:
           fi
 
       - name: Upload Module ZIP as Artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: COPG
           path: ${{ env.ZIP_NAME }}


### PR DESCRIPTION
`upload-artifact@v5` still declares `using: node20` in its action.yml, so it kept appearing in the Node 20 deprecation warning even after the earlier bump. `v6`/`v7` are Node 24 — bumped to **v7** (latest). `checkout@v5` and `setup-java@v5` are already Node 24.