### PR TITLE
library: keep sort/filter controls pinned on scroll

### DIFF
--- a/webroot/css/library.css
+++ b/webroot/css/library.css
@@ -136,8 +136,14 @@
    background. The search row stays sticky (search mid-scroll); the search field
    has its own solid surface so it reads cleanly when content scrolls beneath it.
    No backdrop-filter anywhere here → no Chromium sticky-ghost rectangle. */
-.lib-searchrow {
+/* Sticky header wrapping the search row + sort/filter controls — both stay
+   pinned while the list scrolls. Solid page background hides scrolling content
+   behind it (no see-through gaps). No backdrop-filter → no sticky-ghost. */
+.lib-stickyhead {
   position:sticky; top:0; z-index:20;
+  background:var(--bg-base);
+}
+.lib-searchrow {
   display:flex; align-items:center; gap:10px;
   padding:2px 0 12px;
   background:transparent;

--- a/webroot/js/library.js
+++ b/webroot/js/library.js
@@ -291,23 +291,27 @@ function buildControls() {
       ${SVG_SORT}<span class="lib-sort__label"></span>
     </button>`;
 
-  const devSearch = document.querySelector('#libDevices .lib-searchrow');
-  if (devSearch && !document.querySelector('#libDevices .lib-controls')) {
-    devSearch.insertAdjacentHTML('afterend', `<div class="lib-controls">${sortPill('devices')}</div>`);
-  }
-  const pkgSearch = document.querySelector('#libPackages .lib-searchrow');
-  if (pkgSearch && !document.querySelector('#libPackages .lib-controls')) {
-    pkgSearch.insertAdjacentHTML('afterend', `
-      <div class="lib-controls">
-        ${sortPill('packages')}
+  // Wrap the search row + sort/filter controls in one sticky header so BOTH stay
+  // pinned while the list scrolls (the wrapper carries the solid background).
+  const wrapHead = (panelSel, ctx, filtersHTML = '') => {
+    const search = document.querySelector(`${panelSel} .lib-searchrow`);
+    if (!search || document.querySelector(`${panelSel} .lib-controls`)) return;
+    search.insertAdjacentHTML('afterend', `<div class="lib-controls">${sortPill(ctx)}${filtersHTML}</div>`);
+    const controls = search.nextElementSibling;
+    const head = document.createElement('div');
+    head.className = 'lib-stickyhead';
+    search.parentNode.insertBefore(head, search);
+    head.appendChild(search);
+    head.appendChild(controls);
+  };
+  wrapHead('#libDevices', 'devices');
+  wrapHead('#libPackages', 'packages', `
         <div class="lib-filters">
           <button class="fchip active" data-filter="all" data-i18n="filter_all">All</button>
           <button class="fchip" data-filter="installed" data-i18n="filter_installed">Installed</button>
           <button class="fchip" data-filter="blocked" data-i18n="filter_blocked">Blocked</button>
           <button class="fchip" data-filter="cpu_only" data-i18n="filter_cpu_only">CPU</button>
-        </div>
-      </div>`);
-  }
+        </div>`);
 
   // scope to the Library panels only — the App Picker has its own .lib-sort (#apSort)
   $$('#pageLibrary .lib-sort').forEach(btn => btn.addEventListener('click', e => {


### PR DESCRIPTION
Wraps the search row and the sort/filter controls in a single sticky `.lib-stickyhead` (solid `--bg-base` background) so **both** stay pinned while the device/package list scrolls — previously only the search row was sticky and the sort/filter row scrolled away.