### PR TITLE
library: solid matte-glass sort/filter pills

### DIFF
--- a/webroot/css/library.css
+++ b/webroot/css/library.css
@@ -181,23 +181,29 @@
 }
 .lib-controls::-webkit-scrollbar { display:none; }
 
+/* Sort/filter pills: SOLID matte-glass surface (not see-through) so they read
+   cleanly while sticky over the scrolling list. NO backdrop-filter — that's the
+   sticky-ghost culprit; instead a solid surface + a faint inset top sheen gives
+   the frosted-glass feel without a compositing layer (mirrors the search bar). */
 .lib-sort {
   display:inline-flex; align-items:center; gap:6px; flex-shrink:0;
   padding:5px 11px; border-radius:var(--radius-full);
-  background:var(--glass-bg); border:1px solid var(--glass-border);
+  background:var(--bg-surface-2); border:1px solid var(--glass-border-active);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06), 0 1px 6px rgba(0,0,0,.18);
   color:var(--text-secondary); font-family:var(--font-sans);
   font-size:.74rem; font-weight:600; cursor:pointer; white-space:nowrap;
   outline:none; appearance:none; -webkit-appearance:none;
   transition:background var(--dur-fast) var(--ease-out), transform var(--dur-fast) var(--spring), color var(--dur-fast);
 }
 .lib-sort:active { transform:scale(.94); }
-.lib-sort:hover  { background:var(--glass-bg-hover); color:var(--text-primary); }
+.lib-sort:hover  { background:var(--bg-surface-3); color:var(--text-primary); }
 .lib-sort svg { color:var(--accent-primary); flex-shrink:0; }
 
 .lib-filters { display:flex; align-items:center; gap:6px; flex-shrink:0; }
 .fchip {
   padding:4px 11px; border-radius:var(--radius-full);
-  background:transparent; border:1px solid var(--glass-border);
+  background:var(--bg-surface-2); border:1px solid var(--glass-border-active);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06), 0 1px 6px rgba(0,0,0,.18);
   color:var(--text-secondary); font-family:var(--font-sans);
   font-size:.72rem; font-weight:600; cursor:pointer; white-space:nowrap;
   outline:none; appearance:none; -webkit-appearance:none;
@@ -206,7 +212,8 @@
 }
 .fchip:active { transform:scale(.92); }
 .fchip.active {
-  background:rgba(129,140,248,.14); border-color:rgba(129,140,248,.4); color:var(--accent-primary);
+  background:rgba(129,140,248,.20); border-color:rgba(129,140,248,.5); color:var(--accent-primary);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06), 0 1px 6px rgba(0,0,0,.18);
 }
 
 /* the panel itself slides a touch when swapping via swipe */


### PR DESCRIPTION
Sort pill + filter chips were near-transparent over the scrolling list. Solid `--bg-surface-2` surface + faint inset sheen (no backdrop-filter → no sticky-ghost). Active chip uses a moderate accent fill aligned with the design accent standard.