### PR TITLE
WebUI: Fullscreen toggle + KsuWebUI system-bar inset fix

### DIFF
--- a/webroot/css/base.css
+++ b/webroot/css/base.css
@@ -5,7 +5,11 @@
   box-sizing: border-box; margin: 0; padding: 0;
   -webkit-tap-highlight-color: transparent;
 }
-html { font-size: 16px; -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+/* Paint the document root (the window/ICB that spans the full visual viewport,
+   incl. behind the status bar / notch) with the theme base — otherwise, in
+   immersive fullscreen, 100dvh stops short of the cutout and the bare WebView
+   window shows through as a black band at the top. */
+html { font-size: 16px; -webkit-text-size-adjust: 100%; scroll-behavior: smooth; background: var(--bg-base); transition: background var(--dur-med) var(--ease-out); }
 body {
   font-family: var(--font-sans);
   background: var(--bg-base);
@@ -46,11 +50,12 @@ body::before {
 .scroll-area {
   height: 100%; overflow-y: auto; overflow-x: hidden;
   /* Safe-area insets keep the hero/headers clear of notches, punch-holes &
-     curved edges. max() guarantees a minimum clearance even when the WebUI
-     host reports a 0 inset (viewport-fit=cover is set in index.html). */
-  padding-top:    max(calc(env(safe-area-inset-top, 0px) + 16px), 34px);
-  padding-left:   calc(var(--page-px) + env(safe-area-inset-left, 0px));
-  padding-right:  calc(var(--page-px) + env(safe-area-inset-right, 0px));
+     curved edges. Uses the KsuWebUI window insets (var(--inset-*), env()
+     fallback): when the status bar is shown the top inset clears it; in
+     fullscreen the inset is 0 and content rises to the top edge (like ReZygisk). */
+  padding-top:    calc(var(--inset-top, 0px) + 16px);
+  padding-left:   calc(var(--page-px) + var(--inset-left, 0px));
+  padding-right:  calc(var(--page-px) + var(--inset-right, 0px));
   padding-bottom: 0;
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;

--- a/webroot/css/console.css
+++ b/webroot/css/console.css
@@ -70,7 +70,7 @@
 /* ── Input ── */
 .console-input {
   display:flex; align-items:center; gap:8px; flex-shrink:0;
-  padding:10px 12px calc(env(safe-area-inset-bottom,0px) + 12px);
+  padding:10px 12px calc(var(--inset-bottom,0px) + 12px);
   border-top:1px solid var(--glass-border);
   background:var(--bg-surface-1);
 }

--- a/webroot/css/modals.css
+++ b/webroot/css/modals.css
@@ -56,7 +56,7 @@
 .sheet--form .form-body {
   overflow-y:auto; -webkit-overflow-scrolling:touch;
   scrollbar-width:none;
-  padding-bottom:calc(env(safe-area-inset-bottom,0px) + 20px);
+  padding-bottom:calc(var(--inset-bottom,0px) + 20px);
 }
 .sheet--form .form-body::-webkit-scrollbar { display:none; }
 
@@ -305,7 +305,7 @@
 .picker-body { flex:1; position:relative; min-height:0; }
 .picker-list {
   position:absolute; inset:0; overflow-y:auto; -webkit-overflow-scrolling:touch;
-  padding:0 8px calc(env(safe-area-inset-bottom,0px) + 16px);
+  padding:0 8px calc(var(--inset-bottom,0px) + 16px);
   scrollbar-width:none;
 }
 .picker-list::-webkit-scrollbar { display:none; }

--- a/webroot/css/nav.css
+++ b/webroot/css/nav.css
@@ -7,7 +7,7 @@
   display:flex;align-items:flex-end;justify-content:center;
   padding-top:0;
   /* Float the dock up off the gesture bar / screen edge */
-  padding-bottom:calc(env(safe-area-inset-bottom,0px) + 14px);
+  padding-bottom:calc(var(--inset-bottom,0px) + 14px);
   pointer-events:none;
 }
 .bottom-nav__dock { pointer-events:auto; }

--- a/webroot/css/settings.css
+++ b/webroot/css/settings.css
@@ -62,7 +62,7 @@
   background:var(--sheet-bg);
   border-top:1px solid var(--glass-border);
   border-radius:var(--radius-xl) var(--radius-xl) 0 0;
-  padding-bottom:env(safe-area-inset-bottom,0);
+  padding-bottom:var(--inset-bottom,0px);
   transform:translateY(100%);
   transition:transform var(--dur-slow) var(--spring);
   will-change:transform;

--- a/webroot/css/tokens.css
+++ b/webroot/css/tokens.css
@@ -4,6 +4,14 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 :root {
+  /* Safe-area insets — prefer the KsuWebUI host vars (--window-inset-*, set by
+     the internal insets.css API), fall back to CSS env() for WebUI-X / MMRL /
+     browsers, then 0. Use var(--inset-*) everywhere instead of raw env(). */
+  --inset-top:    var(--window-inset-top,    env(safe-area-inset-top,    0px));
+  --inset-right:  var(--window-inset-right,  env(safe-area-inset-right,  0px));
+  --inset-bottom: var(--window-inset-bottom, env(safe-area-inset-bottom, 0px));
+  --inset-left:   var(--window-inset-left,   env(safe-area-inset-left,   0px));
+
   --accent-primary:   #818CF8;
   --accent-secondary: #A78BFA;
   --accent-glow:      #67E8F9;

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -4,7 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="color-scheme" content="dark light" />
+  <!-- Tints the system status bar to the theme base (kept in sync in theme.js) -->
+  <meta name="theme-color" content="#0A0A12" />
   <title>COPG — Module Dashboard</title>
+  <!-- KsuWebUI host API: injects --window-inset-{top,right,bottom,left} for the
+       real system-bar insets and switches the WebView to edge-to-edge with
+       transparent bars. Without it KsuWebUI draws opaque (black) system bars.
+       Resolves only inside KsuWebUI; harmlessly 404s elsewhere (env() fallback). -->
+  <link rel="stylesheet" href="https://mui.kernelsu.org/internal/insets.css" />
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
@@ -278,6 +285,18 @@
             <span class="setting-row__label" data-i18n="set_language">Language</span>
             <span class="setting-row__value-hint" id="langRowHint">English</span>
             <svg class="setting-row__chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </div>
+          <div class="sys-divider"></div>
+          <!-- Fullscreen (immersive) toggle → ksu.fullScreen bridge -->
+          <div class="setting-row setting-row--toggle">
+            <span class="setting-row__icon">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 3 21 3 21 9"/><polyline points="9 21 3 21 3 15"/><line x1="21" y1="3" x2="14" y2="10"/><line x1="3" y1="21" x2="10" y2="14"/></svg>
+            </span>
+            <span class="setting-row__label" data-i18n="set_fullscreen">Fullscreen</span>
+            <label class="toggle" aria-label="Fullscreen mode">
+              <input type="checkbox" id="fullscreenToggle"/>
+              <span class="toggle__track"><span class="toggle__thumb"></span></span>
+            </label>
           </div>
         </div>
 

--- a/webroot/js/copg-data.js
+++ b/webroot/js/copg-data.js
@@ -985,6 +985,17 @@
   }
 
   /* ─── Public API ─── */
+  /* Immersive fullscreen toggle — KernelSU / ReZygisk WebUI bridge (`ksu.fullScreen`).
+     true = fullscreen (status bar hidden), false = status bar shown. No-op when the
+     bridge is absent (browser preview) or the host doesn't expose `fullScreen`. The
+     page already pads `env(safe-area-inset-top)` (base.css) so content stays clear of
+     the notch/clock while immersive. */
+  function setFullscreen(on) {
+    try {
+      if (typeof ksu !== 'undefined' && typeof ksu.fullScreen === 'function') ksu.fullScreen(!!on);
+    } catch (e) { dlog('fullScreen bridge failed: ' + e, 'warn'); }
+  }
+
   w.COPG = {
     MODULE_DIR, CONFIG_PATH, LIST_PATH, BACKUP_DIR,
     execCommand, hasBridge,
@@ -998,7 +1009,7 @@
     // backup / restore
     backupConfig, listBackups, restoreBackup, restoreFromText, inspectBackup, syncFromGitHub, saveLog,
     // system / device-environment info
-    getSystemInfo,
+    getSystemInfo, setFullscreen,
     // installed apps + icons (KSU API with pm fallback)
     getInstalledPackages, getSystemPackages, isInstalled, getAppLabel, listInstalledApps, enrichApps, fetchPlayIcon, fetchAppIcon,
     // helpers exposed for modals/UI

--- a/webroot/js/lang/ar.js
+++ b/webroot/js/lang/ar.js
@@ -60,6 +60,7 @@ I18N.register('ar', {
   /* Settings rows */
   set_theme:        'السمة',
   set_language:     'اللغة',
+  set_fullscreen:   'ملء الشاشة',
   set_debug:        'سجلات التصحيح',
 
   /* Theme hints */
@@ -94,6 +95,8 @@ I18N.register('ar', {
   toast_console:   'وحدة التحكم — قريباً',
   toast_debug_on:  'تم تفعيل سجلات التصحيح',
   toast_debug_off: 'تم تعطيل سجلات التصحيح',
+  toast_fullscreen_on:  'ملء الشاشة مُفعّل — شريط الحالة مخفي',
+  toast_fullscreen_off: 'ملء الشاشة مُعطّل — شريط الحالة ظاهر',
   status_connected: 'متصل',
   status_offline:   'غير متصل',
 

--- a/webroot/js/lang/de.js
+++ b/webroot/js/lang/de.js
@@ -60,6 +60,7 @@ I18N.register('de', {
   /* Settings rows */
   set_theme:        'Design',
   set_language:     'Sprache',
+  set_fullscreen:   'Vollbild',
   set_debug:        'Debug-Protokolle',
 
   /* Theme hints */
@@ -94,6 +95,8 @@ I18N.register('de', {
   toast_console:   'Konsole — demnächst',
   toast_debug_on:  'Debug-Protokolle aktiviert',
   toast_debug_off: 'Debug-Protokolle deaktiviert',
+  toast_fullscreen_on:  'Vollbild an — Statusleiste ausgeblendet',
+  toast_fullscreen_off: 'Vollbild aus — Statusleiste sichtbar',
   status_connected: 'Verbunden',
   status_offline:   'Offline',
 

--- a/webroot/js/lang/en.js
+++ b/webroot/js/lang/en.js
@@ -60,6 +60,7 @@ I18N.register('en', {
   /* Settings rows */
   set_theme:        'Theme',
   set_language:     'Language',
+  set_fullscreen:   'Fullscreen',
   set_debug:        'Debug Logs',
 
   /* Theme hints (settings row) */
@@ -94,6 +95,8 @@ I18N.register('en', {
   toast_console:   'Console — coming soon',
   toast_debug_on:  'Debug logs enabled',
   toast_debug_off: 'Debug logs disabled',
+  toast_fullscreen_on:  'Fullscreen on — status bar hidden',
+  toast_fullscreen_off: 'Fullscreen off — status bar shown',
   status_connected: 'Connected',
   status_offline:   'Offline',
 

--- a/webroot/js/lang/es.js
+++ b/webroot/js/lang/es.js
@@ -60,6 +60,7 @@ I18N.register('es', {
   /* Settings rows */
   set_theme:        'Tema',
   set_language:     'Idioma',
+  set_fullscreen:   'Pantalla completa',
   set_debug:        'Registros de depuración',
 
   /* Theme hints */
@@ -94,6 +95,8 @@ I18N.register('es', {
   toast_console:   'Consola — próximamente',
   toast_debug_on:  'Registros de depuración activados',
   toast_debug_off: 'Registros de depuración desactivados',
+  toast_fullscreen_on:  'Pantalla completa activada — barra de estado oculta',
+  toast_fullscreen_off: 'Pantalla completa desactivada — barra de estado visible',
   status_connected: 'Conectado',
   status_offline:   'Sin conexión',
 

--- a/webroot/js/lang/fa.js
+++ b/webroot/js/lang/fa.js
@@ -60,6 +60,7 @@ I18N.register('fa', {
   /* Settings rows */
   set_theme:        'پوسته',
   set_language:     'زبان',
+  set_fullscreen:   'تمام‌صفحه',
   set_debug:        'گزارش‌های اشکال‌زدایی',
 
   /* Theme hints (settings row) */
@@ -94,6 +95,8 @@ I18N.register('fa', {
   toast_console:   'کنسول — به‌زودی',
   toast_debug_on:  'گزارش‌های اشکال‌زدایی فعال شد',
   toast_debug_off: 'گزارش‌های اشکال‌زدایی غیرفعال شد',
+  toast_fullscreen_on:  'تمام‌صفحه روشن — نوار وضعیت پنهان شد',
+  toast_fullscreen_off: 'تمام‌صفحه خاموش — نوار وضعیت نمایش داده شد',
   status_connected: 'متصل',
   status_offline:   'آفلاین',
 

--- a/webroot/js/lang/id.js
+++ b/webroot/js/lang/id.js
@@ -60,6 +60,7 @@ I18N.register('id', {
   /* Settings rows */
   set_theme:        'Tema',
   set_language:     'Bahasa',
+  set_fullscreen:   'Layar Penuh',
   set_debug:        'Log Debug',
 
   /* Theme hints */
@@ -94,6 +95,8 @@ I18N.register('id', {
   toast_console:   'Konsol — segera hadir',
   toast_debug_on:  'Log debug diaktifkan',
   toast_debug_off: 'Log debug dinonaktifkan',
+  toast_fullscreen_on:  'Layar penuh aktif — bilah status disembunyikan',
+  toast_fullscreen_off: 'Layar penuh nonaktif — bilah status ditampilkan',
   status_connected: 'Terhubung',
   status_offline:   'Luring',
 

--- a/webroot/js/lang/th.js
+++ b/webroot/js/lang/th.js
@@ -60,6 +60,7 @@ I18N.register('th', {
   /* Settings rows */
   set_theme:        'ธีม',
   set_language:     'ภาษา',
+  set_fullscreen:   'เต็มหน้าจอ',
   set_debug:        'ล็อกดีบัก',
 
   /* Theme hints */
@@ -94,6 +95,8 @@ I18N.register('th', {
   toast_console:   'คอนโซล — เร็ว ๆ นี้',
   toast_debug_on:  'เปิดล็อกดีบักแล้ว',
   toast_debug_off: 'ปิดล็อกดีบักแล้ว',
+  toast_fullscreen_on:  'เปิดเต็มหน้าจอ — ซ่อนแถบสถานะ',
+  toast_fullscreen_off: 'ปิดเต็มหน้าจอ — แสดงแถบสถานะ',
   status_connected: 'เชื่อมต่อแล้ว',
   status_offline:   'ออฟไลน์',
 

--- a/webroot/js/lang/zh.js
+++ b/webroot/js/lang/zh.js
@@ -60,6 +60,7 @@ I18N.register('zh', {
   /* Settings rows */
   set_theme:        '主题',
   set_language:     '语言',
+  set_fullscreen:   '全屏',
   set_debug:        '调试日志',
 
   /* Theme hints */
@@ -94,6 +95,8 @@ I18N.register('zh', {
   toast_console:   '控制台——即将推出',
   toast_debug_on:  '已启用调试日志',
   toast_debug_off: '已禁用调试日志',
+  toast_fullscreen_on:  '全屏已开启 — 状态栏已隐藏',
+  toast_fullscreen_off: '全屏已关闭 — 状态栏已显示',
   status_connected: '已连接',
   status_offline:   '离线',
 

--- a/webroot/js/settings.js
+++ b/webroot/js/settings.js
@@ -19,6 +19,27 @@ if (debugToggle) {
   });
 }
 
+/* ─── Fullscreen (immersive) toggle ───
+   ON = fullscreen (status bar hidden), OFF = status bar shown. Default ON (like
+   ReZygisk's WebUI). Persisted as `copg-fullscreen`; applied via the KSU bridge
+   (`COPG.setFullscreen` → `ksu.fullScreen`) both now (parse time) and on change.
+   No-op in browser preview (no bridge). */
+const fsToggle = $('#fullscreenToggle');
+
+if (fsToggle) {
+  let on = true; // default fullscreen ON
+  try { const v = localStorage.getItem('copg-fullscreen'); if (v !== null) on = v === '1'; } catch(_) {}
+  fsToggle.checked = on;
+  State.fullscreen = on;
+  try { COPG.setFullscreen(on); } catch(_) {}   // apply persisted pref at startup
+  fsToggle.addEventListener('change', () => {
+    State.fullscreen = fsToggle.checked;
+    try { COPG.setFullscreen(fsToggle.checked); } catch(_) {}
+    try { localStorage.setItem('copg-fullscreen', fsToggle.checked ? '1' : '0'); } catch(_) {}
+    showToast(I18N.t(fsToggle.checked ? 'toast_fullscreen_on' : 'toast_fullscreen_off'));
+  });
+}
+
 /* ─── About card expand/collapse ─── */
 const aboutCard = $('#aboutCard');
 aboutCard?.addEventListener('click', () => aboutCard.classList.toggle('expanded'));

--- a/webroot/js/theme.js
+++ b/webroot/js/theme.js
@@ -12,6 +12,13 @@ function applyTheme(theme) {
   } else {
     html.setAttribute('data-theme', theme);
   }
+  // Keep the status-bar tint (theme-color meta) in sync with the resolved base
+  // colour, so the system bar matches instead of showing a black band.
+  try {
+    const base = getComputedStyle(html).getPropertyValue('--bg-base').trim();
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta && base) meta.setAttribute('content', base);
+  } catch(_) {}
   // Update sheet options
   $$('.sheet-option[data-theme-option]').forEach(o => o.classList.toggle('selected', o.dataset.themeOption === theme));
   // Update hint on settings row (localized)


### PR DESCRIPTION
**Feature** (mirrors ReZygisk's WebUI): Settings → Appearance → **Fullscreen** toggle (default ON), persisted as `copg-fullscreen`, applied via `ksu.fullScreen` (new `COPG.setFullscreen`). i18n keys added to all 8 languages.

**Inset fix** (black system-bar band): KsuWebUI doesn't populate `env(safe-area-inset-*)` — it exposes real insets via its host API `mui.kernelsu.org/internal/insets.css` and only then goes edge-to-edge with transparent bars. Included that link; added `--inset-*` tokens (`var(--window-inset-*, env() fallback)`) consumed by every safe-area rule; html painted with `--bg-base` + live `theme-color` meta.