### PR TITLE
Modal: searchable/sortable Device Profile picker

### DIFF
--- a/webroot/css/modals.css
+++ b/webroot/css/modals.css
@@ -111,12 +111,24 @@
 }
 [dir="rtl"] .field__select { background-position:left 12px center; padding-right:14px; padding-left:38px; }
 
+/* Picker-button field (Device Profile) — looks like an input but opens a sheet. */
+.field__picker {
+  display:flex; align-items:center; gap:10px; text-align:start; cursor:pointer;
+}
+.field__picker:active { transform:scale(.99); }
+.field__picker-text {
+  flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+}
+.field__picker-text.is-placeholder { color:var(--text-tertiary); font-weight:400; }
+.field__picker-chevron { flex-shrink:0; color:var(--accent-primary); }
+
 .field-row { display:flex; gap:10px; }
 .field-row .field { flex:1; }
 
 /* validation */
 .field--error .field__input,
-.field--error .field__select { border-color:var(--accent-danger); box-shadow:0 0 0 3px rgba(248,113,113,.14); }
+.field--error .field__select,
+.field--error .field__picker { border-color:var(--accent-danger); box-shadow:0 0 0 3px rgba(248,113,113,.14); }
 .field-msg { font-size:.68rem; color:var(--accent-danger); padding-left:2px; }
 .form-error {
   background:rgba(248,113,113,.1); border:1px solid rgba(248,113,113,.3);
@@ -276,6 +288,7 @@
    pk-* names are deliberately distinct from the Library's lib-* controls so a
    global selector in library.js can never accidentally grab a picker element. */
 .picker-controls { display:flex; align-items:center; gap:8px; margin:0 12px 8px; }
+.pk-spacer { flex:1; }
 .pk-filters {
   display:flex; gap:6px; flex:1; min-width:0;
   overflow-x:auto; scrollbar-width:none; -webkit-overflow-scrolling:touch;
@@ -336,6 +349,16 @@
 .app-row__text  { display:flex; flex-direction:column; min-width:0; gap:1px; }
 .app-row__label { font-size:.85rem; font-weight:600; color:var(--text-primary); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .app-row__pkg   { font-size:.66rem; color:var(--text-tertiary); font-family:var(--font-mono); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+
+/* Device-picker rows: gradient phone avatar + a check on the current selection. */
+.dev-row__avatar {
+  background:linear-gradient(135deg,rgba(129,140,248,.2),rgba(167,139,250,.15));
+  border-color:rgba(129,140,248,.2); color:var(--accent-primary);
+}
+.dev-row .app-row__pkg { font-family:var(--font-sans); font-size:.68rem; }
+.dev-row__check { flex-shrink:0; display:none; color:var(--accent-primary); margin-inline-start:auto; }
+.app-row.is-selected .dev-row__check { display:grid; place-items:center; }
+.app-row.is-selected { background:rgba(129,140,248,.10); }
 
 .picker-loading { display:grid; place-items:center; padding:40px 0; }
 .picker-loading .spin {

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -478,6 +478,7 @@
   <script src="js/home.js"></script>
   <script src="js/modals.js"></script>
   <script src="js/apppicker.js"></script>
+  <script src="js/devicepicker.js"></script>
   <script src="js/console.js"></script>
   <script src="js/gestures.js"></script>
   <script src="js/library.js"></script>

--- a/webroot/js/devicepicker.js
+++ b/webroot/js/devicepicker.js
@@ -1,0 +1,150 @@
+/* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+   devicepicker.js — "Choose a device profile" bottom-sheet
+   Parallel to apppicker.js but for device profiles (COPG.listDevices()):
+   search + A→Z/Z→A sort + tappable rows (device avatar + name + brand·model),
+   with the current selection marked. Shares #sheetOverlay and the .picker-* /
+   .app-row styling. Selecting a row calls back with {pkgKey, name}.
+   window.DevicePicker.open(currentPkgKey, cb)
+   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+(function (w) {
+  const PHONE_SVG = '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="2.5"/><line x1="10" y1="18" x2="14" y2="18"/></svg>';
+  const CHECK_SVG = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
+  document.body.insertAdjacentHTML('beforeend', `
+    <div class="bottom-sheet sheet--picker" id="devPickerSheet" role="dialog" aria-modal="true" aria-label="Device profiles">
+      <div class="sheet-handle"></div>
+      <div class="sheet-header">
+        <span class="sheet-header__title" data-i18n="devpicker_title">Device Profiles</span>
+        <button class="sheet-header__close" id="dpClose" aria-label="Close">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
+      </div>
+      <div class="picker-search">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <input type="search" id="dpSearch" autocomplete="off" data-i18n-attr="placeholder:devpicker_search" placeholder="Search devices…" />
+      </div>
+      <div class="picker-controls">
+        <div class="pk-spacer"></div>
+        <button type="button" class="pk-sort" id="dpSortBtn" aria-label="Sort A→Z / Z→A">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 5v14"/><path d="M4 8l3-3 3 3"/><path d="M14 7h6M14 12h4M14 17h2"/></svg>
+          <span id="dpSortLabel" data-i18n="sort_name">Name (A→Z)</span>
+        </button>
+      </div>
+      <div class="picker-body">
+        <div class="picker-list" id="dpList"></div>
+        <div class="picker-empty" id="dpEmpty" hidden>
+          <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8.5" y1="11" x2="13.5" y2="11"/></svg>
+          <span id="dpEmptyMsg"></span>
+        </div>
+      </div>
+    </div>`);
+
+  const $d = s => document.querySelector(s);
+  const overlay = () => document.getElementById('sheetOverlay');
+  const sheet = () => document.getElementById('devPickerSheet');
+
+  let cb = null;
+  let rowData = [];            // [{el, name, search}]
+  let query = '';
+  let sortDir = 'az';         // 'az' | 'za'
+  let selectedKey = null;
+
+  function close() {
+    const s = sheet();
+    if (s) { s.classList.remove('open'); s.style.transition = ''; s.style.transform = ''; }
+    if (![...document.querySelectorAll('.bottom-sheet.open')].length) overlay()?.classList.remove('visible');
+  }
+  $d('#dpClose').addEventListener('click', close);
+
+  function showEmpty(msg) { $d('#dpEmptyMsg').textContent = msg; $d('#dpEmpty').hidden = false; }
+  function hideEmpty() { $d('#dpEmpty').hidden = true; }
+
+  function render() {
+    const list = $d('#dpList');
+    list.innerHTML = '';
+    rowData = [];
+    const devs = (w.COPG && COPG.listDevices) ? COPG.listDevices() : [];
+    if (!devs.length) {
+      showEmpty(I18N.t('devpicker_empty'));
+      return;
+    }
+    hideEmpty();
+    const frag = document.createDocumentFragment();
+    devs.forEach(d => {
+      const sub = [d.brand, d.model].filter(Boolean).join(' · ');
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'app-row dev-row';
+      row.dataset.key = d.pkgKey;
+      row.classList.toggle('is-selected', d.pkgKey === selectedKey);
+      row.innerHTML =
+        `<span class="app-row__icon dev-row__avatar">${PHONE_SVG}</span>` +
+        `<span class="app-row__text"><span class="app-row__label"></span><span class="app-row__pkg"></span></span>` +
+        `<span class="dev-row__check">${CHECK_SVG}</span>`;
+      row.querySelector('.app-row__label').textContent = d.name;
+      row.querySelector('.app-row__pkg').textContent = sub;
+      row.addEventListener('click', () => {
+        const fn = cb; cb = null;
+        close();
+        if (fn) fn({ pkgKey: d.pkgKey, name: d.name });
+      });
+      frag.appendChild(row);
+      rowData.push({ el: row, name: d.name, search: (d.name + ' ' + sub).toLowerCase() });
+    });
+    list.appendChild(frag);
+    sortRows();
+    applyView();
+  }
+
+  function applyView() {
+    let visible = 0;
+    rowData.forEach(r => {
+      const show = !query || r.search.includes(query);
+      r.el.style.display = show ? '' : 'none';
+      if (show) visible++;
+    });
+    if (rowData.length && visible === 0) showEmpty(I18N.t('picker_no_results'));
+    else hideEmpty();
+  }
+
+  function sortRows() {
+    const dir = sortDir === 'za' ? -1 : 1;
+    rowData.sort((a, b) => dir * a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    const list = $d('#dpList');
+    rowData.forEach(r => list.appendChild(r.el));
+  }
+
+  function updateSortLabel() {
+    const span = $d('#dpSortLabel');
+    if (!span) return;
+    const key = sortDir === 'az' ? 'sort_name' : 'sort_name_za';
+    span.dataset.i18n = key;
+    span.textContent = I18N.t(key);
+  }
+
+  $d('#dpSearch').addEventListener('input', e => { query = e.target.value.trim().toLowerCase(); applyView(); });
+
+  $d('#dpSortBtn').addEventListener('click', () => {
+    sortDir = sortDir === 'az' ? 'za' : 'az';
+    updateSortLabel();
+    sortRows();
+    applyView();
+  });
+
+  function open(currentKey, callback) {
+    cb = callback || null;
+    selectedKey = currentKey || null;
+    query = '';
+    sortDir = 'az'; updateSortLabel();
+    const inp = $d('#dpSearch'); if (inp) inp.value = '';
+    overlay()?.classList.add('visible');
+    const s = sheet();
+    // Clear any residual inline transform left by a drag-to-dismiss gesture
+    // (an inline transform beats the .open stylesheet rule — see apppicker.js).
+    if (s) { s.style.transition = ''; s.style.transform = ''; s.classList.remove('open'); }
+    render();
+    requestAnimationFrame(() => s && s.classList.add('open'));
+  }
+
+  w.DevicePicker = { open };
+})(window);

--- a/webroot/js/lang/ar.js
+++ b/webroot/js/lang/ar.js
@@ -140,6 +140,9 @@ I18N.register('ar', {
   picker_no_results: 'لا توجد تطبيقات',
   picker_preview: 'وضع المعاينة — ثبّت على الجهاز لعرض التطبيقات',
   toast_picker_unavailable: 'منتقي التطبيقات غير متاح هنا',
+  devpicker_title:  'ملفات الأجهزة',
+  devpicker_search: 'ابحث عن الأجهزة…',
+  devpicker_empty:  'لا توجد أجهزة — أضف واحدًا أولاً',
 
   /* Backup & Sync */
   lib_backup:           'النسخ الاحتياطي والمزامنة',
@@ -211,6 +214,7 @@ I18N.register('ar', {
   pkg_f_name:     'اسم العرض',
   pkg_f_type:     'النوع',
   pkg_f_device:   'ملف الجهاز',
+  pkg_pick_device: 'اختر جهازًا…',
   pkg_no_devices: 'لا توجد أجهزة — أضِف واحداً أولاً',
   pkg_sec_spoofing: 'الانتحال',
   pkg_sec_tweaks:   'التعديلات',

--- a/webroot/js/lang/de.js
+++ b/webroot/js/lang/de.js
@@ -140,6 +140,9 @@ I18N.register('de', {
   picker_no_results: 'Keine Apps gefunden',
   picker_preview: 'Vorschaumodus — auf dem Gerät installieren, um Apps aufzulisten',
   toast_picker_unavailable: 'App-Auswahl hier nicht verfügbar',
+  devpicker_title:  'Geräteprofile',
+  devpicker_search: 'Geräte suchen…',
+  devpicker_empty:  'Keine Geräte — zuerst eines hinzufügen',
 
   /* Backup & Sync */
   lib_backup:           'Sicherung & Sync',
@@ -211,6 +214,7 @@ I18N.register('de', {
   pkg_f_name:     'Anzeigename',
   pkg_f_type:     'Typ',
   pkg_f_device:   'Geräteprofil',
+  pkg_pick_device: 'Gerät auswählen…',
   pkg_no_devices: 'Keine Geräte — zuerst eins hinzufügen',
   pkg_sec_spoofing: 'Spoofing',
   pkg_sec_tweaks:   'Optimierungen',

--- a/webroot/js/lang/en.js
+++ b/webroot/js/lang/en.js
@@ -140,6 +140,9 @@ I18N.register('en', {
   picker_no_results: 'No apps found',
   picker_preview: 'Preview mode — install on device to list apps',
   toast_picker_unavailable: 'App picker unavailable here',
+  devpicker_title:  'Device Profiles',
+  devpicker_search: 'Search devices…',
+  devpicker_empty:  'No devices — add one first',
 
   /* Backup & Sync */
   lib_backup:           'Backup & Sync',
@@ -211,6 +214,7 @@ I18N.register('en', {
   pkg_f_name:     'Display Name',
   pkg_f_type:     'Type',
   pkg_f_device:   'Device Profile',
+  pkg_pick_device: 'Choose a device…',
   pkg_no_devices: 'No devices — add one first',
   pkg_sec_spoofing: 'Spoofing',
   pkg_sec_tweaks:   'Tweaks',

--- a/webroot/js/lang/es.js
+++ b/webroot/js/lang/es.js
@@ -140,6 +140,9 @@ I18N.register('es', {
   picker_no_results: 'No se encontraron apps',
   picker_preview: 'Modo vista previa — instala en el dispositivo para ver apps',
   toast_picker_unavailable: 'Selector de apps no disponible aquí',
+  devpicker_title:  'Perfiles de dispositivo',
+  devpicker_search: 'Buscar dispositivos…',
+  devpicker_empty:  'Sin dispositivos — añade uno primero',
 
   /* Backup & Sync */
   lib_backup:           'Copia y sincronización',
@@ -211,6 +214,7 @@ I18N.register('es', {
   pkg_f_name:     'Nombre visible',
   pkg_f_type:     'Tipo',
   pkg_f_device:   'Perfil de dispositivo',
+  pkg_pick_device: 'Elige un dispositivo…',
   pkg_no_devices: 'Sin dispositivos — añade uno primero',
   pkg_sec_spoofing: 'Suplantación',
   pkg_sec_tweaks:   'Ajustes',

--- a/webroot/js/lang/fa.js
+++ b/webroot/js/lang/fa.js
@@ -140,6 +140,9 @@ I18N.register('fa', {
   picker_no_results: 'اپی یافت نشد',
   picker_preview: 'حالت پیش‌نمایش — برای لیست اپ‌ها روی دستگاه نصب کنید',
   toast_picker_unavailable: 'انتخاب‌گر اپ اینجا در دسترس نیست',
+  devpicker_title:  'پروفایل‌های دستگاه',
+  devpicker_search: 'جستجوی دستگاه‌ها…',
+  devpicker_empty:  'دستگاهی نیست — ابتدا یکی اضافه کنید',
 
   /* Backup & Sync */
   lib_backup:           'پشتیبان‌گیری و همگام‌سازی',
@@ -211,6 +214,7 @@ I18N.register('fa', {
   pkg_f_name:     'نام نمایشی',
   pkg_f_type:     'نوع',
   pkg_f_device:   'پروفایل دستگاه',
+  pkg_pick_device: 'یک دستگاه انتخاب کنید…',
   pkg_no_devices: 'دستگاهی نیست — ابتدا یکی اضافه کنید',
   pkg_sec_spoofing: 'جعل',
   pkg_sec_tweaks:   'بهینه‌سازی‌ها',

--- a/webroot/js/lang/id.js
+++ b/webroot/js/lang/id.js
@@ -140,6 +140,9 @@ I18N.register('id', {
   picker_no_results: 'Aplikasi tidak ditemukan',
   picker_preview: 'Mode pratinjau — pasang di perangkat untuk melihat aplikasi',
   toast_picker_unavailable: 'Pemilih aplikasi tidak tersedia di sini',
+  devpicker_title:  'Profil Perangkat',
+  devpicker_search: 'Cari perangkat…',
+  devpicker_empty:  'Tidak ada perangkat — tambahkan dulu',
 
   /* Backup & Sync */
   lib_backup:           'Cadangkan & Sinkron',
@@ -211,6 +214,7 @@ I18N.register('id', {
   pkg_f_name:     'Nama Tampilan',
   pkg_f_type:     'Tipe',
   pkg_f_device:   'Profil Perangkat',
+  pkg_pick_device: 'Pilih perangkat…',
   pkg_no_devices: 'Tidak ada perangkat — tambah dulu',
   pkg_sec_spoofing: 'Pemalsuan',
   pkg_sec_tweaks:   'Penyesuaian',

--- a/webroot/js/lang/th.js
+++ b/webroot/js/lang/th.js
@@ -140,6 +140,9 @@ I18N.register('th', {
   picker_no_results: 'ไม่พบแอป',
   picker_preview: 'โหมดดูตัวอย่าง — ติดตั้งบนอุปกรณ์เพื่อดูรายการแอป',
   toast_picker_unavailable: 'ตัวเลือกแอปใช้ไม่ได้ที่นี่',
+  devpicker_title:  'โปรไฟล์อุปกรณ์',
+  devpicker_search: 'ค้นหาอุปกรณ์…',
+  devpicker_empty:  'ไม่มีอุปกรณ์ — เพิ่มก่อน',
 
   /* Backup & Sync */
   lib_backup:           'สำรองและซิงค์',
@@ -211,6 +214,7 @@ I18N.register('th', {
   pkg_f_name:     'ชื่อที่แสดง',
   pkg_f_type:     'ประเภท',
   pkg_f_device:   'โปรไฟล์อุปกรณ์',
+  pkg_pick_device: 'เลือกอุปกรณ์…',
   pkg_no_devices: 'ไม่มีอุปกรณ์ — เพิ่มก่อน',
   pkg_sec_spoofing: 'การปลอมแปลง',
   pkg_sec_tweaks:   'การปรับแต่ง',

--- a/webroot/js/lang/zh.js
+++ b/webroot/js/lang/zh.js
@@ -140,6 +140,9 @@ I18N.register('zh', {
   picker_no_results: '未找到应用',
   picker_preview: '预览模式——请在设备上安装以列出应用',
   toast_picker_unavailable: '此处无法使用应用选择器',
+  devpicker_title:  '设备配置',
+  devpicker_search: '搜索设备…',
+  devpicker_empty:  '没有设备 — 请先添加',
 
   /* Backup & Sync */
   lib_backup:           '备份与同步',
@@ -211,6 +214,7 @@ I18N.register('zh', {
   pkg_f_name:     '显示名称',
   pkg_f_type:     '类型',
   pkg_f_device:   '设备配置',
+  pkg_pick_device: '选择设备…',
   pkg_no_devices: '没有设备——请先添加一个',
   pkg_sec_spoofing: '伪装',
   pkg_sec_tweaks:   '微调',

--- a/webroot/js/modals.js
+++ b/webroot/js/modals.js
@@ -79,8 +79,11 @@
           </div>
         </div>
 
-        <label class="field" id="pfDeviceField"><span class="field__label" data-i18n="pkg_f_device">Device Profile</span>
-          <select class="field__input field__select" id="pfDevice"></select></label>
+        <div class="field" id="pfDeviceField"><span class="field__label" data-i18n="pkg_f_device">Device Profile</span>
+          <button type="button" class="field__input field__picker" id="pfDevice" data-i18n-attr="aria-label:pkg_f_device" aria-label="Device Profile">
+            <span class="field__picker-text is-placeholder" id="pfDeviceText" data-i18n="pkg_pick_device">Choose a device…</span>
+            <svg class="field__picker-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </button></div>
 
         <div class="toggles" id="pfToggles">
           <div class="toggles__head" id="pfSpoofHead" data-i18n="pkg_sec_spoofing">Spoofing</div>
@@ -180,6 +183,12 @@
     span.className = 'field-msg';
     span.textContent = msg;
     field.appendChild(span);
+  }
+  function clearFieldError(inputEl) {
+    const field = inputEl.closest('.field') || inputEl.parentNode;
+    if (!field) return;
+    field.classList.remove('field--error');
+    field.querySelectorAll('.field-msg').forEach(m => m.remove());
   }
 
   /* ════════════ DEVICE MODAL ════════════ */
@@ -291,26 +300,29 @@
   /* ════════════ PACKAGE MODAL ════════════ */
   let editingPkg = null;  // { clean, type, deviceKey } | null
 
-  function populateDeviceSelect(selectedKey) {
-    const sel = $m('#pfDevice');
-    sel.innerHTML = '';
+  // The device field is now a picker button (opens DevicePicker). The chosen
+  // device's package-array key (PACKAGES_X — what listPackages tags onto
+  // pkg.deviceKey) is stashed in the button's dataset; the label shows its name.
+  function setDeviceSelection(pkgKey) {
+    const btn  = $m('#pfDevice');
+    const text = $m('#pfDeviceText');
     const devs = COPG.listDevices();
-    if (!devs.length) {
-      const o = document.createElement('option');
-      o.value = ''; o.textContent = I18N.t('pkg_no_devices'); o.disabled = true;
-      sel.appendChild(o);
-      return;
+    const dev  = pkgKey ? devs.find(d => d.pkgKey === pkgKey) : null;
+    if (dev) {
+      btn.dataset.deviceKey = dev.pkgKey;
+      text.textContent = dev.name;
+      text.classList.remove('is-placeholder');
+      text.removeAttribute('data-i18n');          // a real value, not the placeholder
+    } else {
+      delete btn.dataset.deviceKey;
+      text.textContent = I18N.t(devs.length ? 'pkg_pick_device' : 'pkg_no_devices');
+      text.classList.add('is-placeholder');
+      text.dataset.i18n = devs.length ? 'pkg_pick_device' : 'pkg_no_devices';
     }
-    devs.forEach(d => {
-      const o = document.createElement('option');
-      // value must be the package-array key (PACKAGES_X) — that's what listPackages
-      // tags onto pkg.deviceKey. Using d.key (PACKAGES_X_DEVICE) broke preselect, so
-      // an edited package silently re-homed to the first device (and to list end).
-      o.value = d.pkgKey; o.textContent = d.name;
-      if (d.pkgKey === selectedKey) o.selected = true;
-      sel.appendChild(o);
-    });
+    clearFieldError(btn);
   }
+  // kept name for the existing call sites (preselect on open/edit)
+  function populateDeviceSelect(selectedKey) { setDeviceSelection(selectedKey); }
 
   // Spoof toggles (with_cpu/blocked/got) are device-type only. Tweak toggles
   // (dnd/dab/kso/nolog) apply to device AND cpu_only. 'blocked' type gets neither.
@@ -338,6 +350,13 @@
 
   // segmented control
   $$('#pfType .seg__opt').forEach(b => b.addEventListener('click', () => setType(b.dataset.type)));
+
+  // Device field → open the searchable/sortable device picker sheet.
+  $m('#pfDevice').addEventListener('click', () => {
+    if (!w.DevicePicker) return;
+    const current = $m('#pfDevice').dataset.deviceKey || null;
+    DevicePicker.open(current, sel => setDeviceSelection(sel.pkgKey));
+  });
   // CPU default is BLOCK (unmount) module-side; "With CPU Spoofing" off = block, so no
   // separate block toggle / mutual-exclusion needed anymore.
 
@@ -414,7 +433,7 @@
     const raw = pkgEl.value.trim();
     const type = currentType();
     const devSel = $m('#pfDevice');
-    const deviceKey = devSel.value || null;
+    const deviceKey = devSel.dataset.deviceKey || null;
 
     let bad = false;
     if (!raw) { markError(pkgEl, I18N.t('msg_required')); bad = true; }


### PR DESCRIPTION
Replaces the Device Profile `<select>` in the package modal with a picker bottom-sheet (parallel to the app picker): **search**, **A→Z / Z→A sort**, device rows with a gradient avatar + `brand · model` subtitle, current selection check-marked. New `js/devicepicker.js`; the modal field is now a `.field__picker` button stashing the chosen `PACKAGES_*` key in its dataset. i18n keys added to all 8 languages.