### PR TITLE
Refresh App Icons action (Backup & Sync sheet)

### DIFF
--- a/webroot/js/backup.js
+++ b/webroot/js/backup.js
@@ -44,6 +44,9 @@
     `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="2"/><rect x="14" y="3" width="7" height="7" rx="2"/><rect x="3" y="14" width="7" height="7" rx="2"/><rect x="14" y="14" width="7" height="7" rx="2" fill="currentColor" stroke="none"/></svg>`;
   const SVG_NAMES =
     `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0l-6.2-6.2a2 2 0 0 1-.6-1.4V5a2 2 0 0 1 2-2h7a2 2 0 0 1 1.4.6l6.4 6.4a2 2 0 0 1 0 2.4z"/><circle cx="8" cy="8" r="1.3" fill="currentColor" stroke="none"/></svg>`;
+  /* image thumbnail + small refresh arc — "re-download app icons" (spins via .is-busy) */
+  const SVG_REFRESH_ICONS =
+    `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="6" width="12" height="12" rx="2"/><circle cx="6.8" cy="9.8" r="1.2"/><path d="M3 14.5 6.5 11l3 3 2-2 2.5 2.5"/><path d="M20.5 5.5a4.5 4.5 0 1 0 .4 4"/><polyline points="21 2 21 5.5 17.5 5.5"/></svg>`;
 
   document.body.insertAdjacentHTML('beforeend', `
     <div class="bottom-sheet sheet--backup" id="backupSheet" role="dialog" aria-modal="true" aria-label="Backup &amp; Restore">
@@ -60,6 +63,15 @@
           <span class="backup-action__text">
             <span class="backup-action__title" data-i18n="backup_sync">Sync from GitHub</span>
             <span class="backup-action__sub" data-i18n="backup_sync_sub">Fetch the latest config from the repo</span>
+          </span>
+          <span class="backup-action__chev">${SVG_CHEV}</span>
+        </button>
+
+        <button type="button" class="backup-action" id="backupRefreshIconsBtn">
+          <span class="backup-action__icon backup-action__icon--sync">${SVG_REFRESH_ICONS}</span>
+          <span class="backup-action__text">
+            <span class="backup-action__title" data-i18n="set_refresh_icons">Refresh App Icons</span>
+            <span class="backup-action__sub" data-i18n="set_refresh_icons_sub">Re-download package icons</span>
           </span>
           <span class="backup-action__chev">${SVG_CHEV}</span>
         </button>
@@ -164,6 +176,29 @@
     } catch (err) {
       showToast(I18N.t('toast_sync_fail'));
       log('Sync failed — ' + err, 'error');
+    } finally {
+      btn.classList.remove('is-busy');
+    }
+  }
+
+  /* ─── Refresh app icons ───
+     Wipe the webroot/icons cache + in-memory state, then repaint the Library so
+     every package icon re-downloads fresh (covers a game changing its icon). */
+  async function doRefreshIcons() {
+    const btn = $b('#backupRefreshIconsBtn');
+    if (btn.classList.contains('is-busy')) return;                 // guard double-tap
+    if (!COPG.hasBridge()) { showToast(I18N.t('toast_icons_refresh_preview')); log('Icon refresh needs the device bridge — unavailable in preview.', 'warn'); return; }
+    btn.classList.add('is-busy');
+    showToast(I18N.t('toast_icons_refreshing'));
+    log('Refresh: wiping cached icons + re-downloading…', 'info');
+    try {
+      if (w.Icons && Icons.refresh) await Icons.refresh();
+      repaintLibrary();                                            // re-runs Icons.load on new rows
+      showToast(I18N.t('toast_icons_refreshed'));
+      log('App icons refreshed.', 'success');
+    } catch (err) {
+      showToast(I18N.t('toast_restore_fail'));
+      log('Icon refresh failed — ' + err, 'error');
     } finally {
       btn.classList.remove('is-busy');
     }
@@ -310,6 +345,7 @@
   $b('#backupExportBtn').addEventListener('click', e => { spawnRipple(e, e.currentTarget); doExport(); });
   $b('#backupImportBtn').addEventListener('click', e => { spawnRipple(e, e.currentTarget); doImport(); });
   $b('#backupSyncBtn').addEventListener('click',   e => { spawnRipple(e, e.currentTarget); doSync(); });
+  $b('#backupRefreshIconsBtn').addEventListener('click', e => { spawnRipple(e, e.currentTarget); doRefreshIcons(); });
   $b('#libBackupBtn')?.addEventListener('click', e => { spawnRipple(e, e.currentTarget); open(); });
 
   function open() {

--- a/webroot/js/copg-data.js
+++ b/webroot/js/copg-data.js
@@ -1033,6 +1033,14 @@
     } catch (_) { return false; }
   }
 
+  /* Wipe every cached icon file so they re-download fresh (e.g. a game changed
+     its icon). The UI then re-renders + re-batches the missing ones. Device only. */
+  async function clearIconCache() {
+    if (!hasBridge()) return false;
+    try { await execCommand(`rm -f ${ICON_DIR_ABS}/*.png ${ICON_DIR_ABS}/.done`); return true; }
+    catch (_) { return false; }
+  }
+
   /* ─── Public API ─── */
   /* Immersive fullscreen toggle — KernelSU / ReZygisk WebUI bridge (`ksu.fullScreen`).
      true = fullscreen (status bar hidden), false = status bar shown. No-op when the
@@ -1061,7 +1069,7 @@
     getSystemInfo, setFullscreen,
     // installed apps + icons (KSU API with pm fallback)
     getInstalledPackages, getSystemPackages, isInstalled, getAppLabel, listInstalledApps, enrichApps,
-    fetchPlayIconUrl, fetchFdroidIconUrl, fetchAppIconUrl, batchFetchIcons,
+    fetchPlayIconUrl, fetchFdroidIconUrl, fetchAppIconUrl, batchFetchIcons, clearIconCache,
     // helpers exposed for modals/UI
     clean, tagsOf, hasTag, deviceKeyFromName, pkgKeyOf,
     sdkFromAndroid, androidFromSdk,

--- a/webroot/js/icons.js
+++ b/webroot/js/icons.js
@@ -48,7 +48,13 @@
   }
 
   function safeName(pkg) { return String(pkg).replace(/[^A-Za-z0-9._-]/g, '_'); }
-  function localUrl(pkg, bust) { return 'icons/' + safeName(pkg) + '.png' + (bust ? ('?v=' + bust) : ''); }
+  // Set on refresh() so subsequent local-file <img> bypass the WebView image
+  // cache (a deleted file may otherwise serve a stale cached hit).
+  let BUST = 0;
+  function localUrl(pkg, bust) {
+    const v = bust || BUST;
+    return 'icons/' + safeName(pkg) + '.png' + (v ? ('?v=' + v) : '');
+  }
 
   /* Inline <svg> fallback — CSP-safe, always renders. */
   function paintSVG(el, pkg, label) { el.innerHTML = genSVGMarkup(pkg, label); }
@@ -156,5 +162,13 @@
     ensureObserver().observe(el);
   }
 
-  w.Icons = { load, genSVGMarkup };
+  /* Wipe cached files + in-memory state so every icon re-downloads fresh.
+     Caller repaints the library afterwards (re-runs Icons.load on new rows). */
+  async function refresh() {
+    WATCH.clear(); PENDING.clear(); clearTimeout(batchTimer);
+    BUST = Date.now();   // cache-bust all subsequent local-file loads
+    if (w.COPG && COPG.clearIconCache) { try { await COPG.clearIconCache(); } catch (_) {} }
+  }
+
+  w.Icons = { load, genSVGMarkup, refresh };
 })(window);

--- a/webroot/js/lang/en.js
+++ b/webroot/js/lang/en.js
@@ -62,6 +62,8 @@ I18N.register('en', {
   set_language:     'Language',
   set_fullscreen:   'Fullscreen',
   set_debug:        'Debug Logs',
+  set_refresh_icons:     'Refresh App Icons',
+  set_refresh_icons_sub: 'Re-download package icons',
 
   /* Theme hints (settings row) */
   theme_auto:   'Auto',
@@ -97,6 +99,9 @@ I18N.register('en', {
   toast_debug_off: 'Debug logs disabled',
   toast_fullscreen_on:  'Fullscreen on — status bar hidden',
   toast_fullscreen_off: 'Fullscreen off — status bar shown',
+  toast_icons_refreshing:     'Refreshing app icons…',
+  toast_icons_refreshed:      'App icons refreshed',
+  toast_icons_refresh_preview:'Icon refresh only works on the device',
   status_connected: 'Connected',
   status_offline:   'Offline',
 

--- a/webroot/js/lang/fa.js
+++ b/webroot/js/lang/fa.js
@@ -62,6 +62,8 @@ I18N.register('fa', {
   set_language:     'زبان',
   set_fullscreen:   'تمام‌صفحه',
   set_debug:        'گزارش‌های اشکال‌زدایی',
+  set_refresh_icons:     'بازخوانی آیکون برنامه‌ها',
+  set_refresh_icons_sub: 'دانلود دوبارهٔ آیکون بسته‌ها',
 
   /* Theme hints (settings row) */
   theme_auto:   'خودکار',
@@ -97,6 +99,9 @@ I18N.register('fa', {
   toast_debug_off: 'گزارش‌های اشکال‌زدایی غیرفعال شد',
   toast_fullscreen_on:  'تمام‌صفحه روشن — نوار وضعیت پنهان شد',
   toast_fullscreen_off: 'تمام‌صفحه خاموش — نوار وضعیت نمایش داده شد',
+  toast_icons_refreshing:      'در حال بازخوانی آیکون‌ها…',
+  toast_icons_refreshed:       'آیکون برنامه‌ها بازخوانی شد',
+  toast_icons_refresh_preview: 'بازخوانی آیکون فقط روی دستگاه کار می‌کند',
   status_connected: 'متصل',
   status_offline:   'آفلاین',
 


### PR DESCRIPTION
Adds a **Refresh App Icons** action to the Backup & Sync sheet (next to Sync from GitHub). Wipes `webroot/icons/*.png` + in-memory icon state, cache-busts, and repaints the Library so every package icon re-downloads fresh (Play→APKPure→F-Droid). Device-only, preview-safe. en/fa strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)