### PR TITLE
Release v5.1.0 (510)

### DIFF
--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -189,8 +189,8 @@ jobs:
 
           chmod 755 module/customize.sh module/service.sh module/uninstall.sh module/META-INF/com/google/android/update-binary
 
-          VERSION="${{ github.event.inputs.custom_version || '5.0.0' }}"
-          VERSION_CODE="${{ github.event.inputs.custom_version_code || '500' }}"
+          VERSION="${{ github.event.inputs.custom_version || '5.1.0' }}"
+          VERSION_CODE="${{ github.event.inputs.custom_version_code || '510' }}"
           cat > module/module.prop << EOF
           id=COPG
           name=✨ COPG SPOOF ✨

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <br>
 
-[![Version](https://img.shields.io/badge/version-5.0.0-818cf8?style=for-the-badge)](https://github.com/AlirezaParsi/COPG/releases)
+[![Version](https://img.shields.io/badge/version-5.1.0-818cf8?style=for-the-badge)](https://github.com/AlirezaParsi/COPG/releases)
 [![Zygisk](https://img.shields.io/badge/Zygisk-Compatible-34d399?style=for-the-badge)](https://github.com/topjohnwu/Magisk)
 [![Android](https://img.shields.io/badge/Android-9.0%2B-3ddc84?style=for-the-badge&logo=android&logoColor=white)](https://www.android.com/)
 [![Downloads](https://img.shields.io/github/downloads/AlirezaParsi/COPG/total?style=for-the-badge&color=f59e0b)](https://github.com/AlirezaParsi/COPG/releases)

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")" && pwd)"
 cd "$REPO"
 
-VERSION="${1:-5.0.0}"
-VERSION_CODE="${2:-500}"
+VERSION="${1:-5.1.0}"
+VERSION_CODE="${2:-510}"
 OUT_DIR="/storage/emulated/0/Download/COPG"
 BUILD_DIR="$REPO/.build"
 STAGE="$BUILD_DIR/module"

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,21 @@
 #### **Telegram Channel**:
 - https://t.me/COPG_module
 ---
+## v5.1.0
+### Faster, Smarter App Icons
+*   **No more lag.** Package icons no longer hammer the root bridge one-by-one — a single background task fetches everything, so the Library stays smooth while icons fill in.
+*   **Three sources:** Google Play → **APKPure** → F-Droid, so games missing from the Play Store (region-locked and the like) still get a real icon.
+*   **Works offline.** Once fetched, icons are cached on-device and load instantly with no network.
+*   **Refresh App Icons:** a new action in **Backup & Sync** wipes the icon cache and re-downloads everything — handy when a game changes its icon.
+
+### WebUI Polish
+*   **Fullscreen toggle:** an immersive mode that hides the status bar, in Settings.
+*   **Device Profile picker:** choosing a device for a package is now a searchable, sortable list instead of a plain dropdown.
+*   Fixed the black band under the status bar / notch in fullscreen, plus navigation-bar and sort/filter spacing touch-ups.
+
+### Game List
+*   Refreshed the bundled device and game profiles (`COPG.json` / `list.json`).
+
 ## v5.0.0
 ### A Complete Reimagining
 *   **Brand-New WebUI:** The entire interface was rebuilt from the ground up with a modern, app-like design — replacing the old single-file UI with a fast, modular one.


### PR DESCRIPTION
Minor bump: lag-free 3-source app icons (Play/APKPure/F-Droid) + offline cache + Refresh action, fullscreen toggle, searchable device picker, inset/nav polish, refreshed game list. No native changes. `update.json` left to the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)