### PR TITLE
i18n: sync icon-refresh keys to all 8 languages

### DIFF
--- a/webroot/js/lang/ar.js
+++ b/webroot/js/lang/ar.js
@@ -62,6 +62,8 @@ I18N.register('ar', {
   set_language:     'اللغة',
   set_fullscreen:   'ملء الشاشة',
   set_debug:        'سجلات التصحيح',
+  set_refresh_icons:     'تحديث أيقونات التطبيقات',
+  set_refresh_icons_sub: 'إعادة تنزيل أيقونات الحزم',
 
   /* Theme hints */
   theme_auto:   'تلقائي',
@@ -97,6 +99,9 @@ I18N.register('ar', {
   toast_debug_off: 'تم تعطيل سجلات التصحيح',
   toast_fullscreen_on:  'ملء الشاشة مُفعّل — شريط الحالة مخفي',
   toast_fullscreen_off: 'ملء الشاشة مُعطّل — شريط الحالة ظاهر',
+  toast_icons_refreshing:      'جارٍ تحديث أيقونات التطبيقات…',
+  toast_icons_refreshed:       'تم تحديث أيقونات التطبيقات',
+  toast_icons_refresh_preview: 'تحديث الأيقونات يعمل على الجهاز فقط',
   status_connected: 'متصل',
   status_offline:   'غير متصل',
 

--- a/webroot/js/lang/de.js
+++ b/webroot/js/lang/de.js
@@ -62,6 +62,8 @@ I18N.register('de', {
   set_language:     'Sprache',
   set_fullscreen:   'Vollbild',
   set_debug:        'Debug-Protokolle',
+  set_refresh_icons:     'App-Icons aktualisieren',
+  set_refresh_icons_sub: 'Paket-Icons neu herunterladen',
 
   /* Theme hints */
   theme_auto:   'Auto',
@@ -97,6 +99,9 @@ I18N.register('de', {
   toast_debug_off: 'Debug-Protokolle deaktiviert',
   toast_fullscreen_on:  'Vollbild an — Statusleiste ausgeblendet',
   toast_fullscreen_off: 'Vollbild aus — Statusleiste sichtbar',
+  toast_icons_refreshing:      'App-Icons werden aktualisiert…',
+  toast_icons_refreshed:       'App-Icons aktualisiert',
+  toast_icons_refresh_preview: 'Icon-Aktualisierung funktioniert nur auf dem Gerät',
   status_connected: 'Verbunden',
   status_offline:   'Offline',
 

--- a/webroot/js/lang/es.js
+++ b/webroot/js/lang/es.js
@@ -62,6 +62,8 @@ I18N.register('es', {
   set_language:     'Idioma',
   set_fullscreen:   'Pantalla completa',
   set_debug:        'Registros de depuración',
+  set_refresh_icons:     'Actualizar iconos de apps',
+  set_refresh_icons_sub: 'Volver a descargar iconos de paquetes',
 
   /* Theme hints */
   theme_auto:   'Auto',
@@ -97,6 +99,9 @@ I18N.register('es', {
   toast_debug_off: 'Registros de depuración desactivados',
   toast_fullscreen_on:  'Pantalla completa activada — barra de estado oculta',
   toast_fullscreen_off: 'Pantalla completa desactivada — barra de estado visible',
+  toast_icons_refreshing:      'Actualizando iconos de apps…',
+  toast_icons_refreshed:       'Iconos de apps actualizados',
+  toast_icons_refresh_preview: 'La actualización de iconos solo funciona en el dispositivo',
   status_connected: 'Conectado',
   status_offline:   'Sin conexión',
 

--- a/webroot/js/lang/id.js
+++ b/webroot/js/lang/id.js
@@ -62,6 +62,8 @@ I18N.register('id', {
   set_language:     'Bahasa',
   set_fullscreen:   'Layar Penuh',
   set_debug:        'Log Debug',
+  set_refresh_icons:     'Segarkan Ikon Aplikasi',
+  set_refresh_icons_sub: 'Unduh ulang ikon paket',
 
   /* Theme hints */
   theme_auto:   'Otomatis',
@@ -97,6 +99,9 @@ I18N.register('id', {
   toast_debug_off: 'Log debug dinonaktifkan',
   toast_fullscreen_on:  'Layar penuh aktif — bilah status disembunyikan',
   toast_fullscreen_off: 'Layar penuh nonaktif — bilah status ditampilkan',
+  toast_icons_refreshing:      'Menyegarkan ikon aplikasi…',
+  toast_icons_refreshed:       'Ikon aplikasi disegarkan',
+  toast_icons_refresh_preview: 'Penyegaran ikon hanya berfungsi di perangkat',
   status_connected: 'Terhubung',
   status_offline:   'Luring',
 

--- a/webroot/js/lang/th.js
+++ b/webroot/js/lang/th.js
@@ -62,6 +62,8 @@ I18N.register('th', {
   set_language:     'ภาษา',
   set_fullscreen:   'เต็มหน้าจอ',
   set_debug:        'ล็อกดีบัก',
+  set_refresh_icons:     'รีเฟรชไอคอนแอป',
+  set_refresh_icons_sub: 'ดาวน์โหลดไอคอนแพ็กเกจใหม่',
 
   /* Theme hints */
   theme_auto:   'อัตโนมัติ',
@@ -97,6 +99,9 @@ I18N.register('th', {
   toast_debug_off: 'ปิดล็อกดีบักแล้ว',
   toast_fullscreen_on:  'เปิดเต็มหน้าจอ — ซ่อนแถบสถานะ',
   toast_fullscreen_off: 'ปิดเต็มหน้าจอ — แสดงแถบสถานะ',
+  toast_icons_refreshing:      'กำลังรีเฟรชไอคอนแอป…',
+  toast_icons_refreshed:       'รีเฟรชไอคอนแอปแล้ว',
+  toast_icons_refresh_preview: 'การรีเฟรชไอคอนใช้ได้เฉพาะบนอุปกรณ์',
   status_connected: 'เชื่อมต่อแล้ว',
   status_offline:   'ออฟไลน์',
 

--- a/webroot/js/lang/zh.js
+++ b/webroot/js/lang/zh.js
@@ -62,6 +62,8 @@ I18N.register('zh', {
   set_language:     '语言',
   set_fullscreen:   '全屏',
   set_debug:        '调试日志',
+  set_refresh_icons:     '刷新应用图标',
+  set_refresh_icons_sub: '重新下载应用包图标',
 
   /* Theme hints */
   theme_auto:   '自动',
@@ -97,6 +99,9 @@ I18N.register('zh', {
   toast_debug_off: '已禁用调试日志',
   toast_fullscreen_on:  '全屏已开启 — 状态栏已隐藏',
   toast_fullscreen_off: '全屏已关闭 — 状态栏已显示',
+  toast_icons_refreshing:      '正在刷新应用图标…',
+  toast_icons_refreshed:       '应用图标已刷新',
+  toast_icons_refresh_preview: '图标刷新仅在设备上可用',
   status_connected: '已连接',
   status_offline:   '离线',
 


### PR DESCRIPTION
Adds the 5 Refresh-App-Icons strings to ar/de/es/id/th/zh — all 8 languages back at full key parity with en.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)