### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,14 @@ development. And a ⭐ on GitHub helps a lot too!
 
 ![Repobeats analytics](https://repobeats.axiom.co/api/embed/83b280d0986b3c023ed5f1fdf3f00f77288e3da3.svg "Repobeats analytics image")
 
+<a href="https://star-history.dera.page/#AlirezaParsi/COPG&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=AlirezaParsi/COPG&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=AlirezaParsi/COPG&type=Date" />
+   <img alt="Star History Chart" width="640" src="https://star-history.dera.page/svg?repos=AlirezaParsi/COPG&type=Date" />
+ </picture>
+</a>
+
 </div>
 
 ---


### PR DESCRIPTION
The Star History chart was dropped in 7d52692 after it broke due to GitHub stargazer API restrictions. This PR restores it in the Activity section using a working provider, so visitors can once again see the project's star growth over time.